### PR TITLE
Preventing log spam when RMQ queue goes missing during replay operation

### DIFF
--- a/backends/rabbitmq/rabbitmq.go
+++ b/backends/rabbitmq/rabbitmq.go
@@ -2,6 +2,7 @@ package rabbitmq
 
 import (
 	"github.com/batchcorp/plumber/cli"
+
 	"github.com/batchcorp/rabbit"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/pkg/errors"
@@ -30,6 +31,7 @@ func New(opts *cli.Options, md *desc.MessageDescriptor) (*RabbitMQ, error) {
 		ExchangeName:   opts.Rabbit.Exchange,
 		RoutingKey:     opts.Rabbit.RoutingKey,
 		QueueExclusive: opts.Rabbit.ReadQueueExclusive,
+		QueueDurable:   opts.Rabbit.ReadQueueDurable,
 		AutoAck:        opts.Rabbit.ReadAutoAck,
 		ConsumerTag:    opts.Rabbit.ReadConsumerTag,
 		AppID:          opts.Rabbit.WriteAppID,

--- a/backends/rabbitmq/relay.go
+++ b/backends/rabbitmq/relay.go
@@ -100,6 +100,7 @@ func (r *Relayer) Relay() error {
 		RoutingKey:   r.Options.Rabbit.RoutingKey,
 		AutoAck:      r.Options.Rabbit.ReadAutoAck,
 		QueueDeclare: r.Options.Rabbit.ReadQueueDeclare,
+		QueueDurable: r.Options.Rabbit.ReadQueueDurable,
 	})
 
 	if err != nil {
@@ -109,6 +110,11 @@ func (r *Relayer) Relay() error {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	go rmq.Consume(ctx, errCh, func(msg amqp.Delivery) error {
+		if msg.Body == nil {
+			// Ignore empty messages
+			// this will also prevent log spam if a queue goes missing
+			return nil
+		}
 		r.log.Debugf("Writing RabbitMQ message to relay channel: %+v", msg)
 		r.RelayCh <- &types.RelayMessage{
 			Value:   &msg,


### PR DESCRIPTION
* Bug: we were not passing ReadQueueDurable's value
* Ignoring empty relay messages to prevent log spam when a queue goes missing while in relay mode