### PR TITLE
Dselans/cli improvements

### DIFF
--- a/ENV.md
+++ b/ENV.md
@@ -40,7 +40,7 @@ Environment Variables
 | `PLUMBER_RELAY_RABBIT_QUEUE`             | Name of the queue where messages will be routed to | **REQUIRED** |
 | `PLUMBER_RELAY_RABBIT_QUEUE_DURABLE`     | Whether the queue we declare should survive server restarts | `false` |
 | `PLUMBER_RELAY_RABBIT_QUEUE_AUTO_DELETE` | Whether to auto-delete the queue after plumber has disconnected | `true` |
-| `PLUMBER_RELAY_RABBIT_QUEUE_EXCLUSIVE`   | Whether plumber should be the only one using the newly defined queue | `true` |
+| `PLUMBER_RELAY_RABBIT_QUEUE_EXCLUSIVE`   | Whether plumber should be the only one using the queue | `false` |
 | `PLUMBER_RELAY_RABBIT_AUTOACK`           | Automatically acknowledge receipt of read/received messages | `true` |
 | `PLUMBER_RELAY_RABBIT_QUEUE_DECLARE`     | Whether to declare the specified queue to create it | `true` |
 | `PLUMBER_RELAY_CONSUMER_TAG`             | How to identify the consumer to RabbitMQ | `plumber` |

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -234,14 +234,26 @@ $ plumber relay
 
 ```bash
 $ plumber read rabbit --address="amqp://localhost" --exchange events --routing-key \# \
-  --line-numbers --output-type protobuf --protobuf-dir ~/schemas \
-  --protobuf-root-message Message --follow
+  --line-numbers --protobuf-dir ~/schemas --protobuf-root-message Message --follow
 1: {"some-attribute": 123, "numbers" : [1, 2, 3]}
 2: {"some-attribute": 424, "numbers" : [325]}
 3: {"some-attribute": 49, "numbers" : [958, 288, 289, 290]}
 4: ERROR: Cannot decode message as protobuf "Message"
 5: {"some-attribute": 394, "numbers" : [4, 5, 6, 7, 8]}
 ^C
+```
+
+#### Writing protobuf messages with source jsonpb
+
+NOTE: "jsonpb" is just a JSON representation of your protobuf event. When you
+use it as the `--input-type`, `plumber` will read the JSON blob and attempt
+to decode it _into_ your specified root message, followed by writing the []byte
+slice to the message bus.
+
+```bash
+$ plumber write rabbit --exchange events --routing-key foo.bar  \
+  --line-numbers --protobuf-dir ~/schemas --protobuf-root-message Message \
+  --input-file ~/fakes/some-jsonpb-file.json --input-type jsonpb
 ```
 
 ##### Using Avro schemas when reading or writing

--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ We consider ourselves "internet plumbers" of sort - so the name seemed to fit :)
 NOTE: If your messaging tech is not supported - submit an issue and we'll do
 our best to make it happen!
 
+### Note on boolean flags
+In order to flip a boolean flag to `false`, prepend `--no` to the flag.
+
+ie. `--queue-declare` is `true` by default. To make it false, use `--no-queue-declare`.
+
 ## Acknowledgments
 
 **Huge** shoutout to [jhump](https://github.com/jhump) and for his excellent

--- a/backends/activemq/read.go
+++ b/backends/activemq/read.go
@@ -22,7 +22,7 @@ func Read(opts *cli.Options) error {
 	var mdErr error
 	var md *desc.MessageDescriptor
 
-	if opts.ReadOutputType == "protobuf" {
+	if opts.ReadProtobufRootMessage != "" {
 		md, mdErr = pb.FindMessageDescriptor(opts.ReadProtobufDirs, opts.ReadProtobufRootMessage)
 		if mdErr != nil {
 			return errors.Wrap(mdErr, "unable to find root message descriptor")
@@ -89,7 +89,8 @@ func validateReadOptions(opts *cli.Options) error {
 		return errors.New("you may only specify a \"topic\" or a \"queue\" not both")
 	}
 
-	if opts.ReadOutputType == "protobuf" {
+	// If anything protobuf-related is specified, it's being used
+	if opts.ReadProtobufRootMessage != "" || len(opts.ReadProtobufDirs) != 0 {
 		if err := cli.ValidateProtobufOptions(
 			opts.ReadProtobufDirs,
 			opts.ReadProtobufRootMessage,

--- a/backends/activemq/write.go
+++ b/backends/activemq/write.go
@@ -18,7 +18,7 @@ func Write(opts *cli.Options) error {
 	var mdErr error
 	var md *desc.MessageDescriptor
 
-	if opts.WriteOutputType == "protobuf" {
+	if opts.WriteInputType == "jsonpb" {
 		md, mdErr = pb.FindMessageDescriptor(opts.WriteProtobufDirs, opts.WriteProtobufRootMessage)
 		if mdErr != nil {
 			return errors.Wrap(mdErr, "unable to find root message descriptor")

--- a/backends/aws-sns/write.go
+++ b/backends/aws-sns/write.go
@@ -23,7 +23,7 @@ func Write(opts *cli.Options) error {
 	var mdErr error
 	var md *desc.MessageDescriptor
 
-	if opts.WriteOutputType == "protobuf" {
+	if opts.WriteInputType == "jsonpb" {
 		md, mdErr = pb.FindMessageDescriptor(opts.WriteProtobufDirs, opts.WriteProtobufRootMessage)
 		if mdErr != nil {
 			return errors.Wrap(mdErr, "unable to find root message descriptor")

--- a/backends/aws-sqs/read.go
+++ b/backends/aws-sqs/read.go
@@ -32,7 +32,7 @@ func Read(opts *cli.Options) error {
 	var mdErr error
 	var md *desc.MessageDescriptor
 
-	if opts.ReadOutputType == "protobuf" {
+	if opts.ReadProtobufRootMessage != "" {
 		md, mdErr = pb.FindMessageDescriptor(opts.ReadProtobufDirs, opts.ReadProtobufRootMessage)
 		if mdErr != nil {
 			return errors.Wrap(mdErr, "unable to find root message descriptor")
@@ -64,7 +64,8 @@ func validateReadOptions(opts *cli.Options) error {
 		return errors.New("--wait-time-seconds must be between 0 and 20")
 	}
 
-	if opts.ReadOutputType == "protobuf" {
+	// If anything protobuf-related is specified, it's being used
+	if opts.ReadProtobufRootMessage != "" || len(opts.ReadProtobufDirs) != 0 {
 		if err := cli.ValidateProtobufOptions(
 			opts.ReadProtobufDirs,
 			opts.ReadProtobufRootMessage,

--- a/backends/aws-sqs/write.go
+++ b/backends/aws-sqs/write.go
@@ -28,7 +28,7 @@ func Write(opts *cli.Options) error {
 	var mdErr error
 	var md *desc.MessageDescriptor
 
-	if opts.WriteOutputType == "protobuf" {
+	if opts.WriteInputType == "jsonpb" {
 		md, mdErr = pb.FindMessageDescriptor(opts.WriteProtobufDirs, opts.WriteProtobufRootMessage)
 		if mdErr != nil {
 			return errors.Wrap(mdErr, "unable to find root message descriptor")

--- a/backends/azure/read.go
+++ b/backends/azure/read.go
@@ -23,7 +23,7 @@ func Read(opts *cli.Options) error {
 	var mdErr error
 	var md *desc.MessageDescriptor
 
-	if opts.ReadOutputType == "protobuf" {
+	if opts.ReadProtobufRootMessage != "" {
 		md, mdErr = pb.FindMessageDescriptor(opts.ReadProtobufDirs, opts.ReadProtobufRootMessage)
 		if mdErr != nil {
 			return errors.Wrap(mdErr, "unable to find root message descriptor")

--- a/backends/azure/write.go
+++ b/backends/azure/write.go
@@ -24,7 +24,7 @@ func Write(opts *cli.Options) error {
 	var mdErr error
 	var md *desc.MessageDescriptor
 
-	if opts.WriteOutputType == "protobuf" {
+	if opts.WriteInputType == "jsonpb" {
 		md, mdErr = pb.FindMessageDescriptor(opts.WriteProtobufDirs, opts.WriteProtobufRootMessage)
 		if mdErr != nil {
 			return errors.Wrap(mdErr, "unable to find root message descriptor")

--- a/backends/gcp-pubsub/read.go
+++ b/backends/gcp-pubsub/read.go
@@ -25,7 +25,7 @@ func Read(opts *cli.Options) error {
 	var mdErr error
 	var md *desc.MessageDescriptor
 
-	if opts.ReadOutputType == "protobuf" {
+	if opts.ReadProtobufRootMessage != "" {
 		md, mdErr = pb.FindMessageDescriptor(opts.ReadProtobufDirs, opts.ReadProtobufRootMessage)
 		if mdErr != nil {
 			return errors.Wrap(mdErr, "unable to find root message descriptor")
@@ -102,7 +102,8 @@ func validateReadOptions(opts *cli.Options) error {
 		return errors.New("GOOGLE_APPLICATION_CREDENTIALS must be set")
 	}
 
-	if opts.ReadOutputType == "protobuf" {
+	// If anything protobuf-related is specified, it's being used
+	if opts.ReadProtobufRootMessage != "" || len(opts.ReadProtobufDirs) != 0 {
 		if err := cli.ValidateProtobufOptions(
 			opts.ReadProtobufDirs,
 			opts.ReadProtobufRootMessage,

--- a/backends/gcp-pubsub/write.go
+++ b/backends/gcp-pubsub/write.go
@@ -26,7 +26,7 @@ func Write(opts *cli.Options) error {
 	var mdErr error
 	var md *desc.MessageDescriptor
 
-	if opts.WriteOutputType == "protobuf" {
+	if opts.WriteInputType == "jsonpb" {
 		md, mdErr = pb.FindMessageDescriptor(opts.WriteProtobufDirs, opts.WriteProtobufRootMessage)
 		if mdErr != nil {
 			return errors.Wrap(mdErr, "unable to find root message descriptor")

--- a/backends/kafka/read.go
+++ b/backends/kafka/read.go
@@ -26,7 +26,7 @@ func Read(opts *cli.Options) error {
 	var mdErr error
 	var md *desc.MessageDescriptor
 
-	if opts.ReadOutputType == "protobuf" {
+	if opts.ReadProtobufRootMessage != "" {
 		md, mdErr = pb.FindMessageDescriptor(opts.ReadProtobufDirs, opts.ReadProtobufRootMessage)
 		if mdErr != nil {
 			return errors.Wrap(mdErr, "unable to find root message descriptor")
@@ -98,9 +98,8 @@ func (k *Kafka) Read() error {
 }
 
 func validateReadOptions(opts *cli.Options) error {
-	// If type is protobuf, ensure both --protobuf-dir and --protobuf-root-message
-	// are set as well
-	if opts.ReadOutputType == "protobuf" {
+	// If anything protobuf-related is specified, it's being used
+	if opts.ReadProtobufRootMessage != "" || len(opts.ReadProtobufDirs) != 0 {
 		if err := cli.ValidateProtobufOptions(
 			opts.ReadProtobufDirs,
 			opts.ReadProtobufRootMessage,

--- a/backends/kafka/write.go
+++ b/backends/kafka/write.go
@@ -26,7 +26,7 @@ func Write(opts *cli.Options) error {
 	var mdErr error
 	var md *desc.MessageDescriptor
 
-	if opts.WriteOutputType == "protobuf" {
+	if opts.WriteInputType == "jsonpb" {
 		md, mdErr = pb.FindMessageDescriptor(opts.WriteProtobufDirs, opts.WriteProtobufRootMessage)
 		if mdErr != nil {
 			return errors.Wrap(mdErr, "unable to find root message descriptor")

--- a/backends/mqtt/read.go
+++ b/backends/mqtt/read.go
@@ -28,7 +28,7 @@ func Read(opts *cli.Options) error {
 	var mdErr error
 	var md *desc.MessageDescriptor
 
-	if opts.ReadOutputType == "protobuf" {
+	if opts.ReadProtobufRootMessage != "" {
 		md, mdErr = pb.FindMessageDescriptor(opts.ReadProtobufDirs, opts.ReadProtobufRootMessage)
 		if mdErr != nil {
 			return errors.Wrap(mdErr, "unable to find root message descriptor")
@@ -133,7 +133,8 @@ func validateReadOptions(opts *cli.Options) error {
 		return errors.New("QoS level can only be 0, 1 or 2")
 	}
 
-	if opts.ReadOutputType == "protobuf" {
+	// If anything protobuf-related is specified, it's being used
+	if opts.ReadProtobufRootMessage != "" || len(opts.ReadProtobufDirs) != 0 {
 		if err := cli.ValidateProtobufOptions(
 			opts.ReadProtobufDirs,
 			opts.ReadProtobufRootMessage,

--- a/backends/mqtt/write.go
+++ b/backends/mqtt/write.go
@@ -26,7 +26,7 @@ func Write(opts *cli.Options) error {
 	var mdErr error
 	var md *desc.MessageDescriptor
 
-	if opts.WriteOutputType == "protobuf" {
+	if opts.WriteInputType == "jsonpb" {
 		md, mdErr = pb.FindMessageDescriptor(opts.WriteProtobufDirs, opts.WriteProtobufRootMessage)
 		if mdErr != nil {
 			return errors.Wrap(mdErr, "unable to find root message descriptor")

--- a/backends/nats/read.go
+++ b/backends/nats/read.go
@@ -22,7 +22,7 @@ func Read(opts *cli.Options) error {
 	var mdErr error
 	var md *desc.MessageDescriptor
 
-	if opts.ReadOutputType == "protobuf" {
+	if opts.ReadProtobufRootMessage != "" {
 		md, mdErr = pb.FindMessageDescriptor(opts.ReadProtobufDirs, opts.ReadProtobufRootMessage)
 		if mdErr != nil {
 			return errors.Wrap(mdErr, "unable to find root message descriptor")

--- a/backends/nats/write.go
+++ b/backends/nats/write.go
@@ -19,7 +19,7 @@ func Write(opts *cli.Options) error {
 	var mdErr error
 	var md *desc.MessageDescriptor
 
-	if opts.WriteOutputType == "protobuf" {
+	if opts.WriteInputType == "jsonpb" {
 		md, mdErr = pb.FindMessageDescriptor(opts.WriteProtobufDirs, opts.WriteProtobufRootMessage)
 		if mdErr != nil {
 			return errors.Wrap(mdErr, "unable to find root message descriptor")

--- a/backends/rabbitmq/rabbitmq.go
+++ b/backends/rabbitmq/rabbitmq.go
@@ -32,6 +32,7 @@ func New(opts *cli.Options, md *desc.MessageDescriptor) (*RabbitMQ, error) {
 		RoutingKey:     opts.Rabbit.RoutingKey,
 		QueueExclusive: opts.Rabbit.ReadQueueExclusive,
 		QueueDurable:   opts.Rabbit.ReadQueueDurable,
+		QueueDeclare:   opts.Rabbit.ReadQueueDeclare,
 		AutoAck:        opts.Rabbit.ReadAutoAck,
 		ConsumerTag:    opts.Rabbit.ReadConsumerTag,
 		AppID:          opts.Rabbit.WriteAppID,

--- a/backends/rabbitmq/read.go
+++ b/backends/rabbitmq/read.go
@@ -28,7 +28,8 @@ func Read(opts *cli.Options) error {
 	var mdErr error
 	var md *desc.MessageDescriptor
 
-	if opts.ReadOutputType == "protobuf" {
+	// Expecting protobuf
+	if opts.ReadProtobufRootMessage != "" {
 		md, mdErr = pb.FindMessageDescriptor(opts.ReadProtobufDirs, opts.ReadProtobufRootMessage)
 		if mdErr != nil {
 			return errors.Wrap(mdErr, "unable to find root message descriptor")
@@ -101,7 +102,8 @@ func validateReadOptions(opts *cli.Options) error {
 		return errors.New("--routing-key cannot be empty with write action")
 	}
 
-	if opts.ReadOutputType == "protobuf" {
+	// If anything protobuf-related is specified, it's being used
+	if opts.ReadProtobufRootMessage != "" || len(opts.ReadProtobufDirs) != 0 {
 		if err := cli.ValidateProtobufOptions(
 			opts.ReadProtobufDirs,
 			opts.ReadProtobufRootMessage,

--- a/backends/rabbitmq/write.go
+++ b/backends/rabbitmq/write.go
@@ -24,7 +24,7 @@ func Write(opts *cli.Options) error {
 	var mdErr error
 	var md *desc.MessageDescriptor
 
-	if opts.WriteOutputType == "protobuf" {
+	if opts.WriteInputType == "jsonpb" {
 		md, mdErr = pb.FindMessageDescriptor(opts.WriteProtobufDirs, opts.WriteProtobufRootMessage)
 		if mdErr != nil {
 			return errors.Wrap(mdErr, "unable to find root message descriptor")

--- a/backends/redis/read.go
+++ b/backends/redis/read.go
@@ -18,7 +18,7 @@ func Read(opts *cli.Options) error {
 	var mdErr error
 	var md *desc.MessageDescriptor
 
-	if opts.ReadOutputType == "protobuf" {
+	if opts.ReadProtobufRootMessage != "" {
 		md, mdErr = pb.FindMessageDescriptor(opts.ReadProtobufDirs, opts.ReadProtobufRootMessage)
 		if mdErr != nil {
 			return errors.Wrap(mdErr, "unable to find root message descriptor")

--- a/backends/redis/write.go
+++ b/backends/redis/write.go
@@ -25,7 +25,7 @@ func Write(opts *cli.Options) error {
 	var mdErr error
 	var md *desc.MessageDescriptor
 
-	if opts.WriteOutputType == "protobuf" {
+	if opts.WriteInputType == "jsonpb" {
 		md, mdErr = pb.FindMessageDescriptor(opts.WriteProtobufDirs, opts.WriteProtobufRootMessage)
 		if mdErr != nil {
 			return errors.Wrap(mdErr, "unable to find root message descriptor")

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -59,7 +59,6 @@ type Options struct {
 	WriteInputData           string
 	WriteInputFile           string
 	WriteInputType           string
-	WriteOutputType          string
 	WriteProtobufDirs        []string
 	WriteProtobufRootMessage string
 
@@ -195,11 +194,9 @@ func HandleGlobalWriteFlags(cmd *kingpin.CmdClause, opts *Options) {
 	cmd.Flag("input-data", "Data to write").StringVar(&opts.WriteInputData)
 	cmd.Flag("input-file", "File containing input data (overrides input-data; 1 file is 1 message)").
 		ExistingFileVar(&opts.WriteInputFile)
-	cmd.Flag("input-type", "Treat input as this type [plain, base64, jsonpb]").
+	cmd.Flag("input-type", "Treat input-file as this type [plain, base64, jsonpb]").
 		Default("plain").
 		EnumVar(&opts.WriteInputType, "plain", "base64", "jsonpb")
-	cmd.Flag("output-type", "Convert input to this type when writing message").
-		Default("plain").EnumVar(&opts.WriteOutputType, "plain", "protobuf")
 	cmd.Flag("protobuf-dir", "Directory with .proto files").
 		Envar("PLUMBER_RELAY_PROTOBUF_DIR").
 		ExistingDirsVar(&opts.WriteProtobufDirs)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -195,7 +195,8 @@ func HandleGlobalWriteFlags(cmd *kingpin.CmdClause, opts *Options) {
 	cmd.Flag("input-data", "Data to write").StringVar(&opts.WriteInputData)
 	cmd.Flag("input-file", "File containing input data (overrides input-data; 1 file is 1 message)").
 		ExistingFileVar(&opts.WriteInputFile)
-	cmd.Flag("input-type", "Treat input as this type").Default("plain").
+	cmd.Flag("input-type", "Treat input as this type [plain, base64, jsonpb]").
+		Default("plain").
 		EnumVar(&opts.WriteInputType, "plain", "base64", "jsonpb")
 	cmd.Flag("output-type", "Convert input to this type when writing message").
 		Default("plain").EnumVar(&opts.WriteOutputType, "plain", "protobuf")

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -51,7 +51,6 @@ type Options struct {
 	// Shared read flags
 	ReadProtobufRootMessage string
 	ReadProtobufDirs        []string
-	ReadOutputType          string
 	ReadFollow              bool
 	ReadLineNumbers         bool
 	ReadConvert             string
@@ -180,10 +179,6 @@ func HandleGlobalReadFlags(cmd *kingpin.CmdClause, opts *Options) {
 
 	cmd.Flag("protobuf-dir", "Directory with .proto files").
 		ExistingDirsVar(&opts.ReadProtobufDirs)
-
-	cmd.Flag("output-type", "The type of message(s) you will receive on the bus").
-		Default("plain").
-		EnumVar(&opts.ReadOutputType, "plain", "protobuf")
 
 	cmd.Flag("follow", "Continuous read (ie. `tail -f`)").
 		Short('f').

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -110,7 +110,6 @@ func TestHandleRabbitFlags_write(t *testing.T) {
 		"--input-data", "welovemessaging",
 		"--input-file", "cli.go",
 		"--input-type", "jsonpb",
-		"--output-type", "protobuf",
 		"--protobuf-dir", "../test-assets/protos",
 		"--protobuf-root-message", "Message",
 		"--avro-schema", "../test-assets/avro/test.avsc",
@@ -127,7 +126,6 @@ func TestHandleRabbitFlags_write(t *testing.T) {
 	g.Expect(opts.WriteInputData).To(Equal("welovemessaging"))
 	g.Expect(opts.WriteInputFile).To(Equal("cli.go"))
 	g.Expect(opts.WriteInputType).To(Equal("jsonpb"))
-	g.Expect(opts.WriteOutputType).To(Equal("protobuf"))
 	g.Expect(opts.WriteProtobufDirs).To(Equal([]string{"../test-assets/protos"}))
 	g.Expect(opts.WriteProtobufRootMessage).To(Equal("Message"))
 	g.Expect(opts.AvroSchemaFile).To(Equal("../test-assets/avro/test.avsc"))
@@ -188,7 +186,6 @@ func TestHandleMQTTFlags_write(t *testing.T) {
 		"--input-data", "welovemessaging",
 		"--input-file", "cli.go",
 		"--input-type", "jsonpb",
-		"--output-type", "protobuf",
 		"--protobuf-dir", "../test-assets/protos",
 		"--protobuf-root-message", "Message",
 		"--avro-schema", "../test-assets/avro/test.avsc",
@@ -209,7 +206,6 @@ func TestHandleMQTTFlags_write(t *testing.T) {
 	g.Expect(opts.WriteInputData).To(Equal("welovemessaging"))
 	g.Expect(opts.WriteInputFile).To(Equal("cli.go"))
 	g.Expect(opts.WriteInputType).To(Equal("jsonpb"))
-	g.Expect(opts.WriteOutputType).To(Equal("protobuf"))
 	g.Expect(opts.WriteProtobufDirs).To(Equal([]string{"../test-assets/protos"}))
 	g.Expect(opts.WriteProtobufRootMessage).To(Equal("Message"))
 	g.Expect(opts.AvroSchemaFile).To(Equal("../test-assets/avro/test.avsc"))
@@ -258,7 +254,6 @@ func TestHandleKafkaFlags_write(t *testing.T) {
 		"--input-data", "welovemessaging",
 		"--input-file", "cli.go",
 		"--input-type", "jsonpb",
-		"--output-type", "protobuf",
 		"--protobuf-dir", "../test-assets/protos",
 		"--protobuf-root-message", "Message",
 		"--avro-schema", "../test-assets/avro/test.avsc",
@@ -272,11 +267,9 @@ func TestHandleKafkaFlags_write(t *testing.T) {
 	g.Expect(opts.Kafka.Topic).To(Equal("plumber_test"))
 	g.Expect(opts.Kafka.WriteKey).To(Equal("plumber_test_key"))
 	g.Expect(opts.Kafka.Timeout).To(Equal(time.Second * 3))
-	g.Expect(opts.WriteOutputType).To(Equal("protobuf"))
 	g.Expect(opts.WriteInputData).To(Equal("welovemessaging"))
 	g.Expect(opts.WriteInputFile).To(Equal("cli.go"))
 	g.Expect(opts.WriteInputType).To(Equal("jsonpb"))
-	g.Expect(opts.WriteOutputType).To(Equal("protobuf"))
 	g.Expect(opts.AvroSchemaFile).To(Equal("../test-assets/avro/test.avsc"))
 }
 
@@ -323,7 +316,6 @@ func TestHandleAWSSQSFlags_write(t *testing.T) {
 		"--input-data", "welovemessaging",
 		"--input-file", "cli.go",
 		"--input-type", "jsonpb",
-		"--output-type", "protobuf",
 		"--protobuf-dir", "../test-assets/protos",
 		"--protobuf-root-message", "Message",
 		"--avro-schema", "../test-assets/avro/test.avsc",
@@ -337,11 +329,9 @@ func TestHandleAWSSQSFlags_write(t *testing.T) {
 	g.Expect(opts.AWSSQS.RemoteAccountID).To(Equal("1234"))
 	g.Expect(opts.AWSSQS.WriteDelaySeconds).To(Equal(int64(6)))
 	g.Expect(opts.AWSSQS.WriteAttributes).To(Equal(map[string]string{"tag": "value"}))
-	g.Expect(opts.WriteOutputType).To(Equal("protobuf"))
 	g.Expect(opts.WriteInputData).To(Equal("welovemessaging"))
 	g.Expect(opts.WriteInputFile).To(Equal("cli.go"))
 	g.Expect(opts.WriteInputType).To(Equal("jsonpb"))
-	g.Expect(opts.WriteOutputType).To(Equal("protobuf"))
 	g.Expect(opts.AvroSchemaFile).To(Equal("../test-assets/avro/test.avsc"))
 }
 
@@ -385,7 +375,6 @@ func TestHandleGCPPubSubFlags_write(t *testing.T) {
 		"--input-data", "welovemessaging",
 		"--input-file", "cli.go",
 		"--input-type", "jsonpb",
-		"--output-type", "protobuf",
 		"--protobuf-dir", "../test-assets/protos",
 		"--protobuf-root-message", "Message",
 		"--avro-schema", "../test-assets/avro/test.avsc",
@@ -397,10 +386,8 @@ func TestHandleGCPPubSubFlags_write(t *testing.T) {
 	g.Expect(cmd).To(Equal("write gcp-pubsub"))
 	g.Expect(opts.GCPPubSub.WriteTopicId).To(Equal("plumber_topic"))
 	g.Expect(opts.GCPPubSub.ProjectId).To(Equal("plumber_project"))
-	g.Expect(opts.WriteOutputType).To(Equal("protobuf"))
 	g.Expect(opts.WriteInputData).To(Equal("welovemessaging"))
 	g.Expect(opts.WriteInputFile).To(Equal("cli.go"))
 	g.Expect(opts.WriteInputType).To(Equal("jsonpb"))
-	g.Expect(opts.WriteOutputType).To(Equal("protobuf"))
 	g.Expect(opts.AvroSchemaFile).To(Equal("../test-assets/avro/test.avsc"))
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -23,7 +23,6 @@ func TestHandleRabbitFlags_read(t *testing.T) {
 		"--no-queue-declare",     // default is true
 		"--no-auto-ack",          // default is true
 		"--consumer-tag", "plumber_123",
-		"--output-type", "plain",
 		"--protobuf-dir", "../test-assets/protos",
 		"--protobuf-root-message", "Message",
 		"--avro-schema", "../test-assets/avro/test.avsc",
@@ -42,7 +41,6 @@ func TestHandleRabbitFlags_read(t *testing.T) {
 	g.Expect(opts.Rabbit.ReadQueueDeclare).To(BeFalse())
 	g.Expect(opts.Rabbit.ReadAutoAck).To(BeFalse())
 	g.Expect(opts.Rabbit.ReadConsumerTag).To(Equal("plumber_123"))
-	g.Expect(opts.ReadOutputType).To(Equal("plain"))
 	g.Expect(opts.ReadProtobufDirs).To(Equal([]string{"../test-assets/protos"}))
 	g.Expect(opts.ReadProtobufRootMessage).To(Equal("Message"))
 	g.Expect(opts.AvroSchemaFile).To(Equal("../test-assets/avro/test.avsc"))
@@ -70,7 +68,6 @@ func TestHandleRabbitFlags_relay(t *testing.T) {
 		"--no-queue-declare",     // default is true
 		"--no-auto-ack",          // default is true
 		"--consumer-tag", "plumber_123",
-		"--output-type", "plain",
 		"--protobuf-dir", "../test-assets/protos",
 		"--protobuf-root-message", "Message",
 		"--avro-schema", "../test-assets/avro/test.avsc",
@@ -95,7 +92,6 @@ func TestHandleRabbitFlags_relay(t *testing.T) {
 	g.Expect(opts.Rabbit.ReadQueueDeclare).To(BeFalse())
 	g.Expect(opts.Rabbit.ReadAutoAck).To(BeFalse())
 	g.Expect(opts.Rabbit.ReadConsumerTag).To(Equal("plumber_123"))
-	g.Expect(opts.ReadOutputType).To(Equal("plain"))
 	g.Expect(opts.ReadProtobufDirs).To(Equal([]string{"../test-assets/protos"}))
 	g.Expect(opts.ReadProtobufRootMessage).To(Equal("Message"))
 	g.Expect(opts.AvroSchemaFile).To(Equal("../test-assets/avro/test.avsc"))
@@ -152,7 +148,6 @@ func TestHandleMQTTFlags_read(t *testing.T) {
 		"--tls-client-cert-file", "cli.go",
 		"--tls-client-key-file", "cli.go",
 		"--insecure-tls", // default is false
-		"--output-type", "plain",
 		"--protobuf-dir", "../test-assets/protos",
 		"--protobuf-root-message", "Message",
 		"--avro-schema", "../test-assets/avro/test.avsc",
@@ -170,7 +165,6 @@ func TestHandleMQTTFlags_read(t *testing.T) {
 	g.Expect(opts.MQTT.TLSCAFile).To(Equal("cli.go"))
 	g.Expect(opts.MQTT.TLSClientKeyFile).To(Equal("cli.go"))
 	g.Expect(opts.MQTT.TLSClientCertFile).To(Equal("cli.go"))
-	g.Expect(opts.ReadOutputType).To(Equal("plain"))
 	g.Expect(opts.ReadProtobufDirs).To(Equal([]string{"../test-assets/protos"}))
 	g.Expect(opts.ReadProtobufRootMessage).To(Equal("Message"))
 	g.Expect(opts.AvroSchemaFile).To(Equal("../test-assets/avro/test.avsc"))
@@ -232,7 +226,6 @@ func TestHandleKafkaFlags_read(t *testing.T) {
 		"--group-id", "plumber_test_group",
 		"--timeout", "3s",
 		"--insecure-tls", // default is false
-		"--output-type", "plain",
 		"--protobuf-dir", "../test-assets/protos",
 		"--protobuf-root-message", "Message",
 		"--avro-schema", "../test-assets/avro/test.avsc",
@@ -246,7 +239,6 @@ func TestHandleKafkaFlags_read(t *testing.T) {
 	g.Expect(opts.Kafka.Topic).To(Equal("plumber_test"))
 	g.Expect(opts.Kafka.ReadGroupId).To(Equal("plumber_test_group"))
 	g.Expect(opts.Kafka.Timeout).To(Equal(time.Second * 3))
-	g.Expect(opts.ReadOutputType).To(Equal("plain"))
 	g.Expect(opts.ReadProtobufDirs).To(Equal([]string{"../test-assets/protos"}))
 	g.Expect(opts.ReadProtobufRootMessage).To(Equal("Message"))
 	g.Expect(opts.AvroSchemaFile).To(Equal("../test-assets/avro/test.avsc"))
@@ -300,7 +292,6 @@ func TestHandleAWSSQSFlags_read(t *testing.T) {
 		"--max-num-messages", "1",
 		"--wait-time-seconds", "3",
 		"--receive-request-attempt-id", "plumber_receiver",
-		"--output-type", "plain",
 		"--protobuf-dir", "../test-assets/protos",
 		"--protobuf-root-message", "Message",
 		"--avro-schema", "../test-assets/avro/test.avsc",
@@ -314,7 +305,6 @@ func TestHandleAWSSQSFlags_read(t *testing.T) {
 	g.Expect(opts.AWSSQS.RemoteAccountID).To(Equal("1234"))
 	g.Expect(opts.AWSSQS.ReadWaitTimeSeconds).To(Equal(int64(3)))
 	g.Expect(opts.AWSSQS.ReadReceiveRequestAttemptId).To(Equal("plumber_receiver"))
-	g.Expect(opts.ReadOutputType).To(Equal("plain"))
 	g.Expect(opts.ReadProtobufDirs).To(Equal([]string{"../test-assets/protos"}))
 	g.Expect(opts.ReadProtobufRootMessage).To(Equal("Message"))
 	g.Expect(opts.AvroSchemaFile).To(Equal("../test-assets/avro/test.avsc"))
@@ -367,7 +357,6 @@ func TestHandleGCPPubSubFlags_read(t *testing.T) {
 		"--sub-id", "plumber_sub",
 		"--project-id", "plumber_project",
 		"--no-ack", // default is true
-		"--output-type", "plain",
 		"--protobuf-dir", "../test-assets/protos",
 		"--protobuf-root-message", "Message",
 		"--avro-schema", "../test-assets/avro/test.avsc",
@@ -380,7 +369,6 @@ func TestHandleGCPPubSubFlags_read(t *testing.T) {
 	g.Expect(opts.GCPPubSub.ReadSubscriptionId).To(Equal("plumber_sub"))
 	g.Expect(opts.GCPPubSub.ProjectId).To(Equal("plumber_project"))
 	g.Expect(opts.GCPPubSub.ReadAck).To(BeFalse())
-	g.Expect(opts.ReadOutputType).To(Equal("plain"))
 	g.Expect(opts.ReadProtobufDirs).To(Equal([]string{"../test-assets/protos"}))
 	g.Expect(opts.ReadProtobufRootMessage).To(Equal("Message"))
 	g.Expect(opts.AvroSchemaFile).To(Equal("../test-assets/avro/test.avsc"))

--- a/cli/rabbit.go
+++ b/cli/rabbit.go
@@ -62,10 +62,10 @@ func addSharedRabbitFlags(cmd *kingpin.CmdClause, opts *Options) {
 	cmd.Flag("exchange", "Name of the exchange").
 		Envar("PLUMBER_RELAY_RABBIT_EXCHANGE").
 		StringVar(&opts.Rabbit.Exchange)
-	cmd.Flag("use-tls", "Force TLS usage (regardless of DSN)").
+	cmd.Flag("use-tls", "Force TLS usage (regardless of DSN) (default: false)").
 		Envar("PLUMBER_RELAY_RABBIT_USE_TLS").
 		BoolVar(&opts.Rabbit.UseTLS)
-	cmd.Flag("skip-verify-tls", "Skip server cert verification").
+	cmd.Flag("skip-verify-tls", "Skip server cert verification (default: false)").
 		Envar("PLUMBER_RELAY_RABBIT_SKIP_VERIFY_TLS").
 		BoolVar(&opts.Rabbit.SkipVerifyTLS)
 
@@ -79,23 +79,23 @@ func addReadRabbitFlags(cmd *kingpin.CmdClause, opts *Options) {
 	cmd.Flag("queue", "Name of the queue where messages will be routed to").
 		Envar("PLUMBER_RELAY_RABBIT_QUEUE").
 		StringVar(&opts.Rabbit.ReadQueue)
-	cmd.Flag("queue-durable", "Whether the queue we declare should survive server restarts").
+	cmd.Flag("queue-durable", "Whether the queue we declare should survive server restarts (default: false)").
 		Default("false").
 		Envar("PLUMBER_RELAY_RABBIT_QUEUE_DURABLE").
 		BoolVar(&opts.Rabbit.ReadQueueDurable)
-	cmd.Flag("queue-auto-delete", "Whether to auto-delete the queue after plumber has disconnected").
+	cmd.Flag("queue-auto-delete", "Whether to auto-delete the queue after plumber has disconnected (default: true)").
 		Default("true").
 		Envar("PLUMBER_RELAY_RABBIT_QUEUE_AUTO_DELETE").
 		BoolVar(&opts.Rabbit.ReadQueueAutoDelete)
-	cmd.Flag("queue-exclusive", "Whether plumber should be the only one using the newly defined queue").
-		Default("true").
+	cmd.Flag("queue-exclusive", "Whether plumber should be the only one using the queue (default: false)").
+		Default("false").
 		Envar("PLUMBER_RELAY_RABBIT_QUEUE_EXCLUSIVE").
 		BoolVar(&opts.Rabbit.ReadQueueExclusive)
-	cmd.Flag("auto-ack", "Automatically acknowledge receipt of read/received messages").
+	cmd.Flag("auto-ack", "Automatically acknowledge receipt of read/received messages (default: true)").
 		Envar("PLUMBER_RELAY_RABBIT_AUTOACK").
 		Default("true").
 		BoolVar(&opts.Rabbit.ReadAutoAck)
-	cmd.Flag("queue-declare", "Whether to declare the specified queue to create it").
+	cmd.Flag("queue-declare", "Whether to declare the specified queue to create it (default: true)").
 		Envar("PLUMBER_RELAY_RABBIT_QUEUE_DECLARE").
 		Default("true").
 		BoolVar(&opts.Rabbit.ReadQueueDeclare)

--- a/main_functional_test.go
+++ b/main_functional_test.go
@@ -109,9 +109,12 @@ var _ = Describe("Functional", func() {
 			Context("jsonpb input, protobuf output", func() {
 				It("should work", func() {
 					// We use "Outbound" here because it's simple
-					cmd := exec.Command(binary, "write", "kafka", "--address", kafkaAddress,
-						"--topic", kafkaTopic, "--input-type", "jsonpb", "--output-type", "protobuf",
-						"--input-file", sampleOutboundJSONPB, "--protobuf-dir", protoSchemasDir,
+					cmd := exec.Command(binary, "write", "kafka",
+						"--address", kafkaAddress,
+						"--topic", kafkaTopic,
+						"--input-type", "jsonpb",
+						"--input-file", sampleOutboundJSONPB,
+						"--protobuf-dir", protoSchemasDir,
 						"--protobuf-root-message", "Outbound")
 
 					_, err := cmd.CombinedOutput()
@@ -264,7 +267,6 @@ var _ = Describe("Functional", func() {
 						"--exchange", exchangeName,
 						"--routing-key", routingKey,
 						"--input-type", "jsonpb",
-						"--output-type", "protobuf",
 						"--input-file", sampleOutboundJSONPB,
 						"--protobuf-dir", protoSchemasDir,
 						"--protobuf-root-message", "Outbound",
@@ -290,7 +292,6 @@ var _ = Describe("Functional", func() {
 						"--exchange", exchangeName,
 						"--routing-key", routingKey,
 						"--queue", queueName,
-						"--output-type", "protobuf",
 						"--protobuf-dir", protoSchemasDir,
 						"--protobuf-root-message", "Outbound",
 					)
@@ -465,7 +466,6 @@ var _ = Describe("Functional", func() {
 						"aws-sqs",
 						"--queue-name", queueName,
 						"--input-type", "jsonpb",
-						"--output-type", "protobuf",
 						"--input-file", sampleOutboundJSONPB,
 						"--protobuf-dir", protoSchemasDir,
 						"--protobuf-root-message", "Outbound",
@@ -484,7 +484,6 @@ var _ = Describe("Functional", func() {
 						"read",
 						"aws-sqs",
 						"--queue-name", queueName,
-						"--output-type", "protobuf",
 						"--protobuf-dir", protoSchemasDir,
 						"--protobuf-root-message", "Outbound",
 					)
@@ -630,7 +629,6 @@ var _ = Describe("Functional", func() {
 						"mqtt",
 						"--topic", topicName,
 						"--input-type", "jsonpb",
-						"--output-type", "protobuf",
 						"--input-file", sampleOutboundJSONPB,
 						"--protobuf-dir", protoSchemasDir,
 						"--protobuf-root-message", "Outbound",
@@ -756,7 +754,6 @@ var _ = Describe("Functional", func() {
 						"activemq",
 						"--queue", queueName,
 						"--input-type", "jsonpb",
-						"--output-type", "protobuf",
 						"--input-file", sampleOutboundJSONPB,
 						"--protobuf-dir", protoSchemasDir,
 						"--protobuf-root-message", "Outbound",
@@ -776,7 +773,6 @@ var _ = Describe("Functional", func() {
 						"read",
 						"activemq",
 						"--queue", queueName,
-						"--output-type", "protobuf",
 						"--protobuf-dir", protoSchemasDir,
 						"--protobuf-root-message", "Outbound",
 					)
@@ -921,7 +917,6 @@ var _ = Describe("Functional", func() {
 						"nats",
 						"--subject", topicName,
 						"--input-type", "jsonpb",
-						"--output-type", "protobuf",
 						"--input-file", sampleOutboundJSONPB,
 						"--protobuf-dir", protoSchemasDir,
 						"--protobuf-root-message", "Outbound",
@@ -1088,7 +1083,6 @@ var _ = Describe("Functional", func() {
 						"redis",
 						"--channel", topicName,
 						"--input-type", "jsonpb",
-						"--output-type", "protobuf",
 						"--input-file", sampleOutboundJSONPB,
 						"--protobuf-dir", protoSchemasDir,
 						"--protobuf-root-message", "Outbound",

--- a/main_functional_test.go
+++ b/main_functional_test.go
@@ -207,7 +207,9 @@ var _ = Describe("Functional", func() {
 					)
 
 					writeOut, err := writeCmd.CombinedOutput()
-					Expect(err).ToNot(HaveOccurred())
+					if err != nil {
+						Fail("write failed: " + string(writeOut))
+					}
 
 					writeGot := string(writeOut[:])
 					writeWant := fmt.Sprintf("Successfully wrote message to exchange '%s'", exchangeName)
@@ -227,11 +229,12 @@ var _ = Describe("Functional", func() {
 						"--exchange", exchangeName,
 						"--routing-key", routingKey,
 						"--queue", queueName,
-						"--no-queue-exclusive",
 					)
 
 					readOutput, err := readCmd.CombinedOutput()
-					Expect(err).ToNot(HaveOccurred())
+					if err != nil {
+						Fail("read failed: " + string(readOutput))
+					}
 
 					if ctx.Err() == context.DeadlineExceeded {
 						Fail("Rabbit plaintext read failed")
@@ -274,7 +277,9 @@ var _ = Describe("Functional", func() {
 					)
 
 					writeOut, err := writeCmd.CombinedOutput()
-					Expect(err).ToNot(HaveOccurred())
+					if err != nil {
+						Fail("write failed: " + string(writeOut))
+					}
 
 					writeGot := string(writeOut[:])
 					writeWant := fmt.Sprintf("Successfully wrote message to exchange '%s'", exchangeName)
@@ -295,11 +300,12 @@ var _ = Describe("Functional", func() {
 						"--queue", queueName,
 						"--protobuf-dir", protoSchemasDir,
 						"--protobuf-root-message", "Outbound",
-						"--no-queue-exclusive",
 					)
 
 					readOut, err := readCmd.CombinedOutput()
-					Expect(err).ToNot(HaveOccurred())
+					if err != nil {
+						Fail("read failed: " + string(readOut))
+					}
 
 					if ctx.Err() == context.DeadlineExceeded {
 						Fail("Rabbit protobuf read failed")
@@ -346,7 +352,9 @@ var _ = Describe("Functional", func() {
 				)
 
 				writeOut, err := writeCmd.CombinedOutput()
-				Expect(err).ToNot(HaveOccurred())
+				if err != nil {
+					Fail("write failed: " + string(writeOut))
+				}
 
 				writeGot := string(writeOut[:])
 				writeWant := fmt.Sprintf("Successfully wrote message to exchange '%s'", exchangeName)
@@ -365,11 +373,12 @@ var _ = Describe("Functional", func() {
 					"--exchange", exchangeName,
 					"--routing-key", routingKey,
 					"--queue", queueName,
-					"--no-queue-exclusive",
 				)
 
 				readOutput, err := readCmd.CombinedOutput()
-				Expect(err).ToNot(HaveOccurred())
+				if err != nil {
+					Fail("read failed: " + string(readOutput))
+				}
 
 				if ctx.Err() == context.DeadlineExceeded {
 					Fail("Rabbit AVRO read failed")
@@ -1040,7 +1049,9 @@ var _ = Describe("Functional", func() {
 					)
 
 					writeOut, err := writeCmd.CombinedOutput()
-					Expect(err).ToNot(HaveOccurred())
+					if err != nil {
+						Fail("write failed: " + string(writeOut))
+					}
 
 					writeGot := string(writeOut[:])
 
@@ -1092,7 +1103,9 @@ var _ = Describe("Functional", func() {
 					)
 
 					writeOut, err := writeCmd.CombinedOutput()
-					Expect(err).ToNot(HaveOccurred())
+					if err != nil {
+						Fail("write failed: " + string(writeOut))
+					}
 
 					writeGot := string(writeOut[:])
 					writeWant := fmt.Sprintf("Successfully wrote message to '%s'", topicName)
@@ -1145,7 +1158,9 @@ var _ = Describe("Functional", func() {
 					)
 
 					writeOut, err := writeCmd.CombinedOutput()
-					Expect(err).ToNot(HaveOccurred())
+					if err != nil {
+						Fail("write failed: " + string(writeOut))
+					}
 
 					writeGot := string(writeOut[:])
 

--- a/main_functional_test.go
+++ b/main_functional_test.go
@@ -227,6 +227,7 @@ var _ = Describe("Functional", func() {
 						"--exchange", exchangeName,
 						"--routing-key", routingKey,
 						"--queue", queueName,
+						"--no-queue-exclusive",
 					)
 
 					readOutput, err := readCmd.CombinedOutput()
@@ -294,6 +295,7 @@ var _ = Describe("Functional", func() {
 						"--queue", queueName,
 						"--protobuf-dir", protoSchemasDir,
 						"--protobuf-root-message", "Outbound",
+						"--no-queue-exclusive",
 					)
 
 					readOut, err := readCmd.CombinedOutput()
@@ -363,6 +365,7 @@ var _ = Describe("Functional", func() {
 					"--exchange", exchangeName,
 					"--routing-key", routingKey,
 					"--queue", queueName,
+					"--no-queue-exclusive",
 				)
 
 				readOutput, err := readCmd.CombinedOutput()
@@ -1250,7 +1253,8 @@ func createRabbit(exchangeName, queueName, routingKey string) error {
 	if err != nil {
 		return err
 	}
-	cmd = exec.Command("docker", "exec", "rabbitmq", "rabbitmqadmin", "declare", "queue", "name="+queueName)
+
+	cmd = exec.Command("docker", "exec", "rabbitmq", "rabbitmqadmin", "declare", "queue", "name="+queueName, "durable=false")
 	_, err = cmd.CombinedOutput()
 	if err != nil {
 		return err

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -16,7 +16,7 @@ import (
 )
 
 func Decode(opts *cli.Options, msgDesc *desc.MessageDescriptor, message []byte) ([]byte, error) {
-	if opts.ReadOutputType == "protobuf" {
+	if opts.ReadProtobufRootMessage != "" {
 		// SQS doesn't like binary
 		if opts.AWSSQS.QueueName != "" {
 			// Our implementation of 'protobuf-over-sqs' encodes protobuf in b64
@@ -59,7 +59,7 @@ func Decode(opts *cli.Options, msgDesc *desc.MessageDescriptor, message []byte) 
 		message = decoded
 	}
 
-	data := make([]byte, 0)
+	var data []byte
 
 	var convertErr error
 

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -36,8 +36,8 @@ func GenerateWriteValue(md *desc.MessageDescriptor, opts *cli.Options) ([]byte, 
 	}
 
 	// Ensure we do not try to operate on a nil md
-	if opts.WriteOutputType == "protobuf" && md == nil {
-		return nil, errors.New("message descriptor cannot be nil when --output-type is protobuf")
+	if opts.WriteInputFile == "jsonpb" && md == nil {
+		return nil, errors.New("message descriptor cannot be nil when --input-type is jsonpb")
 	}
 
 	// Handle AVRO
@@ -57,12 +57,12 @@ func GenerateWriteValue(md *desc.MessageDescriptor, opts *cli.Options) ([]byte, 
 	}
 
 	// Input: Plain Output: Plain
-	if opts.WriteInputType == "plain" && opts.WriteOutputType == "plain" {
+	if opts.WriteInputType == "plain" {
 		return data, nil
 	}
 
 	// Input: JSONPB Output: Protobuf
-	if opts.WriteInputType == "jsonpb" && opts.WriteOutputType == "protobuf" {
+	if opts.WriteInputType == "jsonpb" {
 		var convertErr error
 
 		data, convertErr = convertJSONPBToProtobuf(data, dynamic.NewMessage(md))
@@ -78,11 +78,7 @@ func GenerateWriteValue(md *desc.MessageDescriptor, opts *cli.Options) ([]byte, 
 		return data, nil
 	}
 
-	// TODO: Input: Base64 Output: Plain
-	// TODO: Input: Base64 Output: Protobuf
-	// TODO: And a few more combinations ...
-
-	return nil, errors.New("unsupported input/output combination")
+	return nil, errors.New("unsupported --input-type")
 }
 
 // ValidateWriteOptions ensures that the correct flags and their values have been provided.
@@ -97,7 +93,7 @@ func ValidateWriteOptions(opts *cli.Options, busSpecific func(options *cli.Optio
 
 	// If type is protobuf, ensure both --protobuf-dir and --protobuf-root-message
 	// are set as well
-	if opts.WriteOutputType == "protobuf" {
+	if opts.WriteInputType == "jsonpb" {
 		if err := cli.ValidateProtobufOptions(
 			opts.WriteProtobufDirs,
 			opts.WriteProtobufRootMessage,
@@ -112,7 +108,7 @@ func ValidateWriteOptions(opts *cli.Options, busSpecific func(options *cli.Optio
 
 	// InputData and file cannot be set at the same time
 	if opts.WriteInputData != "" && opts.WriteInputFile != "" {
-		return fmt.Errorf("--value and --file cannot both be set")
+		return fmt.Errorf("--input-data and --input-file cannot both be set")
 	}
 
 	if opts.WriteInputFile != "" {


### PR DESCRIPTION
CLI improvements: remove '--output-type' for reading; remove '--input-type' for writing. Both are unnecessary and the intent can be gathered from other flags.

Minor bugfix: --queue-declare now actually declares the queue for rabbit (previously, the setting didn't do anything).