### PR TITLE
set kafka read offset; add kafka read tests

### DIFF
--- a/ENV.md
+++ b/ENV.md
@@ -49,20 +49,22 @@ Environment Variables
 
 | Environment Variable  | Description | Default |
 | --------------------- | ------------| ------- |
-| `PLUMBER_RELAY_KAFKA_ADDRESS`           | Destination host address | `localhost:9092` |
-| `PLUMBER_RELAY_KAFKA_TOPIC`             | Topic to read message(s) from | **REQUIRED** |
-| `PLUMBER_RELAY_KAFKA_TIMEOUT`           | Connect timeout | `10s` |
-| `PLUMBER_RELAY_KAFKA_INSECURE_TLS`      | Use insecure TLS (ie. do not verify cert) | `false` |
-| `PLUMBER_RELAY_KAFKA_USERNAME`          | SASL Username | |
-| `PLUMBER_RELAY_KAFKA_PASSWORD`          | SASL Password. If omitted, you will be prompted for the password | |
-| `PLUMBER_RELAY_KAFKA_SASL_TYPE`         | SASL Authentication type (plain or scram) | `scram` |
-| `PLUMBER_RELAY_KAFKA_GROUP_ID`          | Specify a specific group-id to use when reading from kafka | `plumber` | 
-| `PLUMBER_RELAY_KAFKA_MAX_WAIT`          | How long to wait for new data when reading batches of messages | `1s` |
-| `PLUMBER_RELAY_KAFKA_MIN_BYTES`         | Minimum number of bytes to fetch in a single kafka request (throughput optimization) | `1` |
-| `PLUMBER_RELAY_KAFKA_MAX_BYTES`         | Maximum number of bytes to fetch in a single kafka request (throughput optimization) | `1` |
-| `PLUMBER_RELAY_KAFKA_QUEUE_CAPACITY`    | Internal queue capacity (throughput optimization) | `1` |
-| `PLUMBER_RELAY_KAFKA_REBALANCE_TIMEOUT` | How long a coordinator will wait for member joins as part of a rebalance | `0` |
-| `PLUMBER_RELAY_KAFKA_COMMIT_INTERVAL`   | How often to commit offsets to broker (0 = synchronous) | `5s` | 
+| `PLUMBER_RELAY_KAFKA_ADDRESS`            | Destination host address | `localhost:9092` |
+| `PLUMBER_RELAY_KAFKA_TOPIC`              | Topic to read message(s) from | **REQUIRED** |
+| `PLUMBER_RELAY_KAFKA_TIMEOUT`            | Connect timeout | `10s` |
+| `PLUMBER_RELAY_KAFKA_INSECURE_TLS`       | Use insecure TLS (ie. do not verify cert) | `false` |
+| `PLUMBER_RELAY_KAFKA_USERNAME`           | SASL Username | |
+| `PLUMBER_RELAY_KAFKA_PASSWORD`           | SASL Password. If omitted, you will be prompted for the password | |
+| `PLUMBER_RELAY_KAFKA_SASL_TYPE`          | SASL Authentication type (plain or scram) | `scram` |
+| `PLUMBER_RELAY_KAFKA_USE_CONSUMER_GROUP` | Use consumer  | `true` |
+| `PLUMBER_RELAY_KAFKA_GROUP_ID`           | Specify a specific group-id to use when reading from kafka | `plumber` | 
+| `PLUMBER_RELAY_KAFKA_READ_OFFSET`        | At what offset should consumer start reading (NOTE: offset is ignored if plumber is using consumer group) | `0` |
+| `PLUMBER_RELAY_KAFKA_MAX_WAIT`           | How long to wait for new data when reading batches of messages | `1s` |
+| `PLUMBER_RELAY_KAFKA_MIN_BYTES`          | Minimum number of bytes to fetch in a single kafka request (throughput optimization) | `1` |
+| `PLUMBER_RELAY_KAFKA_MAX_BYTES`          | Maximum number of bytes to fetch in a single kafka request (throughput optimization) | `1` |
+| `PLUMBER_RELAY_KAFKA_QUEUE_CAPACITY`     | Internal queue capacity (throughput optimization) | `1` |
+| `PLUMBER_RELAY_KAFKA_REBALANCE_TIMEOUT`  | How long a coordinator will wait for member joins as part of a rebalance | `0` |
+| `PLUMBER_RELAY_KAFKA_COMMIT_INTERVAL`    | How often to commit offsets to broker (0 = synchronous) | `5s` | 
 
 **NOTE**: For _Confluent-hosted_ Kafka, you MUST set:
 

--- a/backends/kafka/read.go
+++ b/backends/kafka/read.go
@@ -108,5 +108,9 @@ func validateReadOptions(opts *cli.Options) error {
 		}
 	}
 
+	if opts.Kafka.ReadOffset < 0 {
+		return errors.New("read offset must be >= 0")
+	}
+
 	return nil
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -233,7 +233,7 @@ func TestHandleKafkaFlags_read(t *testing.T) {
 	g.Expect(cmd).To(Equal("read kafka"))
 	g.Expect(opts.Kafka.Address).To(Equal("testing.tld:9092"))
 	g.Expect(opts.Kafka.Topic).To(Equal("plumber_test"))
-	g.Expect(opts.Kafka.ReadGroupId).To(Equal("plumber_test_group"))
+	g.Expect(opts.Kafka.GroupID).To(Equal("plumber_test_group"))
 	g.Expect(opts.Kafka.Timeout).To(Equal(time.Second * 3))
 	g.Expect(opts.ReadProtobufDirs).To(Equal([]string{"../test-assets/protos"}))
 	g.Expect(opts.ReadProtobufRootMessage).To(Equal("Message"))

--- a/cli/kafka.go
+++ b/cli/kafka.go
@@ -25,6 +25,7 @@ const (
 	DefaultKafkaRelayQueueCapacity    = "1000"
 	DefaultKafkaRelayRebalanceTimeout = "5s"
 	DefaultKafkaRelayCommitInterval   = "5s"
+	DefaultKafkaReadOffset            = "0"
 )
 
 type KafkaOptions struct {
@@ -38,7 +39,9 @@ type KafkaOptions struct {
 	AuthenticationType string
 
 	// Read
-	ReadGroupId      string
+	UseConsumerGroup bool
+	GroupID          string
+	ReadOffset       int64 // If UseConsumerGroup is true, ReadOffset will NOT be used
 	MaxWait          time.Duration
 	MinBytes         int
 	MaxBytes         int
@@ -119,10 +122,18 @@ func addReadKafkaFlags(cmd *kingpin.CmdClause, opts *Options) {
 		defaultRebalanceTimeout = DefaultKafkaRelayRebalanceTimeout
 	}
 
+	cmd.Flag("use-consumer-group", "Whether plumber should use a consumer group").
+		Envar("PLUMBER_RELAY_KAFKA_USE_CONSUMER_GROUP").
+		Default("true").
+		BoolVar(&opts.Kafka.UseConsumerGroup)
 	cmd.Flag("group-id", "Specify a specific group-id to use when reading from kafka").
 		Envar("PLUMBER_RELAY_KAFKA_GROUP_ID").
 		Default(DefaultKafkaGroupId).
-		StringVar(&opts.Kafka.ReadGroupId)
+		StringVar(&opts.Kafka.GroupID)
+	cmd.Flag("read-offset", "Specify what offset the consumer should read from (only works if '--use-consumer-group' is false)").
+		Envar("PLUMBER_RELAY_KAFKA_READ_OFFSET").
+		Default(DefaultKafkaReadOffset).
+		Int64Var(&opts.Kafka.ReadOffset)
 	cmd.Flag("max-wait", "How long to wait for new data when reading batches of messages").
 		Envar("PLUMBER_RELAY_KAFKA_MAX_WAIT").
 		Default(defaultMaxWait).


### PR DESCRIPTION
This PR introduces the ability to set a read offset when using kafka. 

Added functional tests for testing reads with and without offsets.