### PR TITLE
Minor relay fixes:

### DIFF
--- a/backends/kafka/relay.go
+++ b/backends/kafka/relay.go
@@ -108,7 +108,7 @@ func (r *Relayer) Relay() error {
 			stats.Mute("kafka-relay-consumer")
 			stats.Mute("kafka-relay-producer")
 
-			r.log.Errorf("Unable to read kafka message: %s; retrying in %s", RetryReadInterval)
+			r.log.Errorf("Unable to read kafka message: %s; retrying in %s", err, RetryReadInterval)
 
 			continue
 		}

--- a/backends/rpubsub/relay.go
+++ b/backends/rpubsub/relay.go
@@ -118,8 +118,8 @@ func (r *Relayer) Relay() error {
 		msg, err := sub.ReceiveMessage(r.DefaultContext)
 		if err != nil {
 			// Temporarily mute stats
-			stats.Mute("redis-relay-consumer")
-			stats.Mute("redis-relay-producer")
+			stats.Mute("redis-pubsub-relay-consumer")
+			stats.Mute("redis-pubsub-relay-producer")
 
 			r.log.Errorf("Unable to read message: %s (retrying in %s)", err, RetryReadInterval)
 
@@ -128,7 +128,7 @@ func (r *Relayer) Relay() error {
 			continue
 		}
 
-		stats.Incr("redis-relay-consumer", 1)
+		stats.Incr("redis-pubsub-relay-consumer", 1)
 
 		r.log.Debugf("Relaying message received on channel '%s' to Batch (contents: %s)",
 			msg.Channel, msg.Payload)

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -248,7 +248,7 @@ func (r *Relay) flush(ctx context.Context, conn *grpc.ClientConn, messages ...in
 		err = r.handleGCP(ctx, conn, messages)
 	case *redisTypes.RelayMessage:
 		r.log.Debugf("flushing %d redis-pubsub message(s)", len(messages))
-		relayType = "redis"
+		relayType = "redis-pubsub"
 		err = r.handleRedisPubSub(ctx, conn, messages)
 	case *rstreamsTypes.RelayMessage:
 		r.log.Debugf("flushing %d redis-streams message(s)", len(messages))


### PR DESCRIPTION
- Fix redis-streams stats display (wasn't increasing stats or muting on error)
- Fix bug where redis-streams relay incorrectly exits on error (should run forever and just log error)
- Kafka relay stats now get muted when read results in an error (+ retry in `5s`)
- Add RetryReadInterval on error for gcp pubsub relay
- Add RetryReadInterval on error for aws-sqs relay