### PR TITLE
Ungroup cdc-postgres changes

### DIFF
--- a/backends/cdc-mongo/cdc-mongo.go
+++ b/backends/cdc-mongo/cdc-mongo.go
@@ -2,13 +2,18 @@ package cdc_mongo
 
 import (
 	"context"
+	"time"
+
 	"github.com/batchcorp/plumber/cli"
 	"github.com/batchcorp/plumber/printer"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"time"
+)
+
+var (
+	errMissingDatabase = errors.New("you must specify the --database flag")
 )
 
 type CDCMongo struct {

--- a/backends/cdc-mongo/relay.go
+++ b/backends/cdc-mongo/relay.go
@@ -2,10 +2,12 @@ package cdc_mongo
 
 import (
 	"context"
+
 	"github.com/batchcorp/plumber/api"
 	"github.com/batchcorp/plumber/backends/cdc-mongo/types"
 	"github.com/batchcorp/plumber/cli"
 	"github.com/batchcorp/plumber/relay"
+	"github.com/batchcorp/plumber/stats"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -91,6 +93,7 @@ func (r *Relayer) Relay() error {
 			r.log.Errorf("unable to read message from mongo: %s", cs.Err())
 		}
 
+		stats.Incr("cdc-mongo-relay-consumer", 1)
 		r.RelayCh <- &types.RelayMessage{
 			Value: cs.Current,
 		}

--- a/backends/cdc-postgres/cdc-postgres.go
+++ b/backends/cdc-postgres/cdc-postgres.go
@@ -2,9 +2,15 @@ package cdc_postgres
 
 import (
 	"crypto/tls"
+	"fmt"
+
+	"github.com/batchcorp/pgoutput"
+	"github.com/batchcorp/plumber/backends/cdc-postgres/types"
 	"github.com/batchcorp/plumber/cli"
 	"github.com/batchcorp/plumber/printer"
 	"github.com/jackc/pgx"
+	"github.com/jackc/pgx/pgtype"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -59,4 +65,99 @@ func NewService(opts *cli.Options) (*pgx.ReplicationConn, error) {
 	}
 
 	return conn, nil
+}
+
+func handleInsert(set *pgoutput.RelationSet, v *pgoutput.Insert, changeRecord *types.ChangeRecord) (*types.ChangeRecord, error) {
+	changeSet, ok := set.Get(v.RelationID)
+	if !ok {
+		return nil, errors.New("relation not found")
+	}
+	values, err := set.Values(v.RelationID, v.Row)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing values: %s", err)
+	}
+
+	record := &types.ChangeRecord{
+		LSN:       changeRecord.LSN,
+		XID:       changeRecord.XID,
+		Timestamp: changeRecord.Timestamp,
+		Table:     changeSet.Name,
+		Operation: "insert",
+		Fields:    make(map[string]interface{}, 0),
+	}
+
+	for name, value := range values {
+		record.Fields[name] = value.Get()
+	}
+
+	return record, nil
+}
+
+func handleUpdate(set *pgoutput.RelationSet, v *pgoutput.Update, changeRecord *types.ChangeRecord) (*types.ChangeRecord, error) {
+	changeSet, ok := set.Get(v.RelationID)
+	if !ok {
+		return nil, errors.New("relation not found")
+	}
+	values, err := set.Values(v.RelationID, v.Row)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing values: %s", err)
+	}
+
+	record := &types.ChangeRecord{
+		LSN:       changeRecord.LSN,
+		XID:       changeRecord.XID,
+		Timestamp: changeRecord.Timestamp,
+		Table:     changeSet.Name,
+		Operation: "update",
+		Fields:    make(map[string]interface{}, 0),
+		OldFields: make(map[string]interface{}, 0),
+	}
+
+	for name, value := range values {
+		record.Fields[name] = value.Get()
+	}
+
+	oldValues, err := set.Values(v.RelationID, v.OldRow)
+	if err == nil {
+		for name, value := range oldValues {
+			record.OldFields[name] = value
+		}
+	}
+
+	return record, nil
+}
+
+func handleDelete(set *pgoutput.RelationSet, v *pgoutput.Delete, changeRecord *types.ChangeRecord) (*types.ChangeRecord, error) {
+	changeSet, ok := set.Get(v.RelationID)
+	if !ok {
+		err := fmt.Errorf("relation not found for '%s'", changeSet.Name)
+		return nil, err
+	}
+	values, err := set.Values(v.RelationID, v.Row)
+	if err != nil {
+		values = make(map[string]pgtype.Value, 0)
+		return nil, err
+	}
+
+	record := &types.ChangeRecord{
+		LSN:       changeRecord.LSN,
+		XID:       changeRecord.XID,
+		Timestamp: changeRecord.Timestamp,
+		Table:     changeSet.Name,
+		Operation: "delete",
+		Fields:    make(map[string]interface{}, 0),
+	}
+
+	for name, value := range values {
+		val := value.Get()
+
+		// Deletes will include the primary key with the rest of the fields being empty. Ignore them
+		if val == "" {
+			continue
+		}
+
+		record.Fields[name] = val
+	}
+
+	return record, nil
 }

--- a/backends/cdc-postgres/read.go
+++ b/backends/cdc-postgres/read.go
@@ -3,13 +3,12 @@ package cdc_postgres
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+
 	"github.com/batchcorp/pgoutput"
 	"github.com/batchcorp/plumber/backends/cdc-postgres/types"
 	"github.com/batchcorp/plumber/cli"
 	"github.com/batchcorp/plumber/printer"
 	"github.com/jackc/pgx"
-	"github.com/jackc/pgx/pgtype"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -39,109 +38,52 @@ func (p *CDCPostgres) Read() error {
 	set := pgoutput.NewRelationSet(nil)
 
 	var changeRecord *types.ChangeRecord
-	changeRecord = &types.ChangeRecord{}
-	changeRecord.Changes = make([]*types.Change, 0)
 
 	sub := pgoutput.NewSubscription(p.Service, p.Options.CDCPostgres.SlotName, p.Options.CDCPostgres.PublisherName, 0, false)
 
 	handler := func(m pgoutput.Message, _ uint64) error {
 		switch v := m.(type) {
 		case pgoutput.Begin:
-			changeRecord.Timestamp = v.Timestamp.UTC().UnixNano()
-			changeRecord.XID = v.XID
+			changeRecord = &types.ChangeRecord{
+				Timestamp: v.Timestamp.UTC().UnixNano(),
+				XID:       v.XID,
+				LSN:       pgx.FormatLSN(v.LSN),
+			}
 		case pgoutput.Commit:
-			changeRecord.LSN = pgx.FormatLSN(v.LSN)
-
 			// Advance LSN so we do not read the same messages on re-connect
 			sub.AdvanceLSN(v.LSN + 1)
-
-			output, _ := json.MarshalIndent(changeRecord, "", "  ")
-			p.Printer.Print(string(output))
-
-			changeRecord = &types.ChangeRecord{}
-			changeRecord.Changes = make([]*types.Change, 0)
 		case pgoutput.Relation:
 			set.Add(v)
 		case pgoutput.Insert:
-			changeSet, ok := set.Get(v.RelationID)
-			if !ok {
-				return errors.New("relation not found")
-			}
-			values, err := set.Values(v.RelationID, v.Row)
+			record, err := handleInsert(set, &v, changeRecord)
 			if err != nil {
-				return fmt.Errorf("error parsing values: %s", err)
-			}
-
-			change := &types.Change{
-				Operation: "insert",
-				Table:     changeSet.Name,
-				Fields:    make(map[string]interface{}, 0),
-			}
-			for name, value := range values {
-				change.Fields[name] = value.Get()
-			}
-			changeRecord.Changes = append(changeRecord.Changes, change)
-		case pgoutput.Update:
-			changeSet, ok := set.Get(v.RelationID)
-			if !ok {
-				return errors.New("relation not found")
-			}
-			values, err := set.Values(v.RelationID, v.Row)
-			if err != nil {
-				return fmt.Errorf("error parsing values: %s", err)
-			}
-
-			change := &types.Change{
-				Operation: "update",
-				Table:     changeSet.Name,
-				Fields:    make(map[string]interface{}, 0),
-				OldFields: make(map[string]interface{}, 0),
-			}
-			for name, value := range values {
-				change.Fields[name] = value.Get()
-			}
-
-			oldValues, err := set.Values(v.RelationID, v.OldRow)
-			if err == nil {
-				for name, value := range oldValues {
-					change.OldFields[name] = value
-				}
-			}
-
-			changeRecord.Changes = append(changeRecord.Changes, change)
-		case pgoutput.Delete:
-			changeSet, ok := set.Get(v.RelationID)
-			if !ok {
-				err := fmt.Errorf("relation not found for '%s'", changeSet.Name)
-				p.Log.Error(err)
 				return err
 			}
-			values, err := set.Values(v.RelationID, v.Row)
+
+			p.printRecord(record)
+		case pgoutput.Update:
+			record, err := handleUpdate(set, &v, changeRecord)
 			if err != nil {
-				values = make(map[string]pgtype.Value, 0)
-				p.Log.Debugf("Error parsing value: %s", err)
+				return err
 			}
 
-			change := &types.Change{
-				Operation: "delete",
-				Table:     changeSet.Name,
-				Fields:    make(map[string]interface{}, 0),
+			p.printRecord(record)
+		case pgoutput.Delete:
+			record, err := handleDelete(set, &v, changeRecord)
+			if err != nil {
+				return err
 			}
-			for name, value := range values {
-				val := value.Get()
 
-				// Deletes will include the primary key with the rest of the fields being empty. Ignore them
-				if val == "" {
-					continue
-				}
-
-				change.Fields[name] = val
-			}
-			changeRecord.Changes = append(changeRecord.Changes, change)
+			p.printRecord(record)
 		}
 		return nil
 	}
 	return sub.Start(context.Background(), 0, handler)
+}
+
+func (p *CDCPostgres) printRecord(record *types.ChangeRecord) {
+	output, _ := json.MarshalIndent(record, "", "  ")
+	p.Printer.Print(string(output))
 }
 
 // validateReadOptions ensures the correct CLI options are specified for the read action

--- a/backends/cdc-postgres/relay.go
+++ b/backends/cdc-postgres/relay.go
@@ -2,14 +2,14 @@ package cdc_postgres
 
 import (
 	"context"
-	"fmt"
+
 	"github.com/batchcorp/pgoutput"
 	"github.com/batchcorp/plumber/api"
 	"github.com/batchcorp/plumber/backends/cdc-postgres/types"
 	"github.com/batchcorp/plumber/cli"
 	"github.com/batchcorp/plumber/relay"
+	"github.com/batchcorp/plumber/stats"
 	"github.com/jackc/pgx"
-	"github.com/jackc/pgx/pgtype"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -72,8 +72,6 @@ func (r *Relayer) Relay() error {
 	set := pgoutput.NewRelationSet(nil)
 
 	var changeRecord *types.ChangeRecord
-	changeRecord = &types.ChangeRecord{}
-	changeRecord.Changes = make([]*types.Change, 0)
 
 	sub := pgoutput.NewSubscription(r.Service, r.Options.CDCPostgres.SlotName, r.Options.CDCPostgres.PublisherName, 0, false)
 	defer r.Service.Close()
@@ -82,100 +80,46 @@ func (r *Relayer) Relay() error {
 
 		switch v := m.(type) {
 		case pgoutput.Begin:
-			changeRecord.Timestamp = v.Timestamp.UTC().UnixNano()
-			changeRecord.XID = v.XID
+			changeRecord = &types.ChangeRecord{
+				Timestamp: v.Timestamp.UTC().UnixNano(),
+				XID:       v.XID,
+				LSN:       pgx.FormatLSN(v.LSN),
+			}
 		case pgoutput.Commit:
-			changeRecord.LSN = pgx.FormatLSN(v.LSN)
-
 			// Advance LSN so we do not read the same messages on re-connect
 			sub.AdvanceLSN(v.LSN + 1)
-
-			if len(changeRecord.Changes) > 0 {
-				r.RelayCh <- &types.RelayMessage{
-					Value: changeRecord,
-				}
-			}
-
-			changeRecord = &types.ChangeRecord{}
-			changeRecord.Changes = make([]*types.Change, 0)
 		case pgoutput.Relation:
 			set.Add(v)
 		case pgoutput.Insert:
-			changeSet, ok := set.Get(v.RelationID)
-			if !ok {
-				return errors.New("relation not found")
-			}
-			values, err := set.Values(v.RelationID, v.Row)
+			record, err := handleInsert(set, &v, changeRecord)
 			if err != nil {
-				return fmt.Errorf("error parsing values: %s", err)
-			}
-
-			change := &types.Change{
-				Operation: "insert",
-				Table:     changeSet.Name,
-				Fields:    make(map[string]interface{}, 0),
-			}
-			for name, value := range values {
-				change.Fields[name] = value.Get()
-			}
-			changeRecord.Changes = append(changeRecord.Changes, change)
-		case pgoutput.Update:
-			changeSet, ok := set.Get(v.RelationID)
-			if !ok {
-				return errors.New("relation not found")
-			}
-			values, err := set.Values(v.RelationID, v.Row)
-			if err != nil {
-				return fmt.Errorf("error parsing values: %s", err)
-			}
-
-			change := &types.Change{
-				Operation: "update",
-				Table:     changeSet.Name,
-				Fields:    make(map[string]interface{}, 0),
-				OldFields: make(map[string]interface{}, 0),
-			}
-			for name, value := range values {
-				change.Fields[name] = value.Get()
-			}
-
-			oldValues, err := set.Values(v.RelationID, v.OldRow)
-			if err == nil {
-				for name, value := range oldValues {
-					change.OldFields[name] = value
-				}
-			}
-
-			changeRecord.Changes = append(changeRecord.Changes, change)
-		case pgoutput.Delete:
-			changeSet, ok := set.Get(v.RelationID)
-			if !ok {
-				err := fmt.Errorf("relation not found for '%s'", changeSet.Name)
-				r.log.Error(err)
 				return err
 			}
-			values, err := set.Values(v.RelationID, v.Row)
+
+			stats.Incr("cdc-postgres-relay-consumer", 1)
+			r.RelayCh <- &types.RelayMessage{
+				Value: record,
+			}
+		case pgoutput.Update:
+			record, err := handleUpdate(set, &v, changeRecord)
 			if err != nil {
-				values = make(map[string]pgtype.Value, 0)
-				r.log.Debugf("Error parsing value: %s", err)
+				return err
 			}
 
-			change := &types.Change{
-				Operation: "delete",
-				Table:     changeSet.Name,
-				Fields:    make(map[string]interface{}, 0),
+			stats.Incr("cdc-postgres-relay-consumer", 1)
+			r.RelayCh <- &types.RelayMessage{
+				Value: record,
 			}
-			for name, value := range values {
-				val := value.Get()
-
-				// Deletes will include the primary key with the rest of the fields being empty. Ignore them
-				if val == "" {
-					continue
-				}
-
-				change.Fields[name] = val
+		case pgoutput.Delete:
+			record, err := handleDelete(set, &v, changeRecord)
+			if err != nil {
+				return err
 			}
-			changeRecord.Changes = append(changeRecord.Changes, change)
+
+			stats.Incr("cdc-postgres-relay-consumer", 1)
+			r.RelayCh <- &types.RelayMessage{
+				Value: record,
+			}
 		}
 
 		return nil

--- a/backends/cdc-postgres/types/types.go
+++ b/backends/cdc-postgres/types/types.go
@@ -7,10 +7,13 @@ type RelayMessage struct {
 }
 
 type ChangeRecord struct {
-	LSN       string    `json:"lsn"`
-	XID       int32     `json:"xid"`
-	Timestamp int64     `json:"timestamp"`
-	Changes   []*Change `json:"changes"`
+	LSN       string                 `json:"lsn"`
+	XID       int32                  `json:"xid"`
+	Timestamp int64                  `json:"timestamp"`
+	Table     string                 `json:"table"`
+	Operation string                 `json:"operation"`
+	Fields    map[string]interface{} `json:"fields"`
+	OldFields map[string]interface{} `json:"old_fields,omitempty"`
 }
 
 type Change struct {

--- a/cli/cdc-mongo.go
+++ b/cli/cdc-mongo.go
@@ -1,8 +1,9 @@
 package cli
 
 import (
-	"gopkg.in/alecthomas/kingpin.v2"
 	"os"
+
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type CDCMongoOptions struct {
@@ -39,7 +40,6 @@ func addSharedMongoFlags(cmd *kingpin.CmdClause, opts *Options) {
 		StringVar(&opts.CDCMongo.DSN)
 
 	cmd.Flag("database", "Database Name").
-		Required().
 		Envar("PLUMBER_RELAY_CDCMONGO_DATABASE").
 		StringVar(&opts.CDCMongo.Database)
 


### PR DESCRIPTION
* A new record is shipped for every change, instead of grouping by commit
* Fix: Adding missing stats.Incr() calls for cdc-postgres and cdc-mongo
* Improvement: cdc-postgres code deduplication