### PR TITLE
In container mode, force JSON logs and do not print logo

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 
+	"golang.org/x/crypto/ssh/terminal"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/batchcorp/plumber/backends/activemq"
@@ -46,7 +48,12 @@ func main() {
 		stats.Start(opts.StatsReportInterval)
 	}
 
-	printer.PrintLogo()
+	// In container mode, force JSON and don't print logo
+	if !terminal.IsTerminal(int(os.Stderr.Fd())) {
+		logrus.SetFormatter(&logrus.JSONFormatter{})
+	} else {
+		printer.PrintLogo()
+	}
 
 	if strings.HasPrefix(cmd, "relay") {
 		printer.PrintRelayOptions(cmd, opts)

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/batchcorp/schemas/build/go/services"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/crypto/ssh/terminal"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
@@ -65,11 +63,6 @@ func New(relayCfg *Config) (*Relay, error) {
 	// Verify grpc connection & token
 	if err := TestConnection(relayCfg); err != nil {
 		return nil, errors.Wrap(err, "unable to complete connection test")
-	}
-
-	// JSON formatter for log output if not running in a TTY - colors are fun!
-	if !terminal.IsTerminal(int(os.Stderr.Fd())) {
-		logrus.SetFormatter(&logrus.JSONFormatter{})
 	}
 
 	return &Relay{


### PR DESCRIPTION
Relay info was outputting as standard string logs as it is printed before the relayer is started. Also easier just to define this in main()