### PR TITLE
Relay graceful shutdown mode

### DIFF
--- a/backends/aws-sqs/relay.go
+++ b/backends/aws-sqs/relay.go
@@ -20,12 +20,12 @@ const (
 )
 
 type Relayer struct {
-	Options         *cli.Options
-	Service         *sqs.SQS
-	QueueURL        string
-	RelayCh         chan interface{}
-	ShutdownContext context.Context
-	log             *logrus.Entry
+	Options     *cli.Options
+	Service     *sqs.SQS
+	QueueURL    string
+	RelayCh     chan interface{}
+	ShutdownCtx context.Context
+	log         *logrus.Entry
 }
 
 func Relay(opts *cli.Options, relayCh chan interface{}, shutdownCtx context.Context) (relay.IRelayBackend, error) {
@@ -40,12 +40,12 @@ func Relay(opts *cli.Options, relayCh chan interface{}, shutdownCtx context.Cont
 	}
 
 	r := &Relayer{
-		Service:         svc,
-		QueueURL:        queueURL,
-		Options:         opts,
-		RelayCh:         relayCh,
-		ShutdownContext: shutdownCtx,
-		log:             logrus.WithField("pkg", "aws-sqs/relay"),
+		Service:     svc,
+		QueueURL:    queueURL,
+		Options:     opts,
+		RelayCh:     relayCh,
+		ShutdownCtx: shutdownCtx,
+		log:         logrus.WithField("pkg", "aws-sqs/relay"),
 	}
 
 	return r, nil
@@ -69,18 +69,15 @@ func (r *Relayer) Relay() error {
 
 	r.log.Infof("HTTP server listening on '%s'", r.Options.RelayHTTPListenAddress)
 
-	// TODO: Optionally print out relay and SQS config
-
 	for {
 		select {
-		case <-r.ShutdownContext.Done():
+		case <-r.ShutdownCtx.Done():
 			r.log.Info("Received shutdown signal, existing relayer")
 			return nil
 		default:
 			// noop
 		}
 
-		// TODO: does this block or not?
 		// Read message(s) from SQS
 		msgResult, err := r.Service.ReceiveMessage(&sqs.ReceiveMessageInput{
 			MaxNumberOfMessages:     aws.Int64(r.Options.AWSSQS.RelayMaxNumMessages),

--- a/backends/azure/relay.go
+++ b/backends/azure/relay.go
@@ -14,12 +14,12 @@ import (
 )
 
 type Relayer struct {
-	Options         *cli.Options
-	RelayCh         chan interface{}
-	log             *logrus.Entry
-	Queue           *servicebus.Queue
-	Topic           *servicebus.Topic
-	ShutdownContext context.Context
+	Options     *cli.Options
+	RelayCh     chan interface{}
+	log         *logrus.Entry
+	Queue       *servicebus.Queue
+	Topic       *servicebus.Topic
+	ShutdownCtx context.Context
 }
 
 func Relay(opts *cli.Options, relayCh chan interface{}, shutdownCtx context.Context) (relay.IRelayBackend, error) {
@@ -30,10 +30,10 @@ func Relay(opts *cli.Options, relayCh chan interface{}, shutdownCtx context.Cont
 	}
 
 	r := &Relayer{
-		Options:         opts,
-		RelayCh:         relayCh,
-		ShutdownContext: shutdownCtx,
-		log:             logrus.WithField("pkg", "azure/relay.go"),
+		Options:     opts,
+		RelayCh:     relayCh,
+		ShutdownCtx: shutdownCtx,
+		log:         logrus.WithField("pkg", "azure/relay.go"),
 	}
 
 	if opts.Azure.Queue != "" {
@@ -57,9 +57,9 @@ func Relay(opts *cli.Options, relayCh chan interface{}, shutdownCtx context.Cont
 
 // readQueue reads messages from an ASB queue
 func (r *Relayer) readQueue(handler servicebus.HandlerFunc) error {
-	defer r.Queue.Close(r.ShutdownContext)
+	defer r.Queue.Close(r.ShutdownCtx)
 	for {
-		if err := r.Queue.ReceiveOne(r.ShutdownContext, handler); err != nil {
+		if err := r.Queue.ReceiveOne(r.ShutdownCtx, handler); err != nil {
 			if err == context.Canceled {
 				r.log.Info("Received shutdown signal, existing relayer")
 				return nil
@@ -77,10 +77,10 @@ func (r *Relayer) readTopic(handler servicebus.HandlerFunc) error {
 		return errors.Wrap(err, "unable to create topic subscription")
 	}
 
-	defer sub.Close(r.ShutdownContext)
+	defer sub.Close(r.ShutdownCtx)
 
 	for {
-		if err := sub.ReceiveOne(r.ShutdownContext, handler); err != nil {
+		if err := sub.ReceiveOne(r.ShutdownCtx, handler); err != nil {
 			if err == context.Canceled {
 				r.log.Info("Received shutdown signal, existing relayer")
 				return nil

--- a/backends/azure/relay.go
+++ b/backends/azure/relay.go
@@ -4,11 +4,9 @@ import (
 	"context"
 
 	servicebus "github.com/Azure/azure-service-bus-go"
-	"github.com/jhump/protoreflect/desc"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"github.com/batchcorp/plumber/api"
 	"github.com/batchcorp/plumber/backends/azure/types"
 	"github.com/batchcorp/plumber/cli"
 	"github.com/batchcorp/plumber/relay"
@@ -16,97 +14,78 @@ import (
 )
 
 type Relayer struct {
-	Options        *cli.Options
-	MsgDesc        *desc.MessageDescriptor
-	RelayCh        chan interface{}
-	log            *logrus.Entry
-	Queue          *servicebus.Queue
-	Topic          *servicebus.Topic
-	DefaultContext context.Context
+	Options         *cli.Options
+	RelayCh         chan interface{}
+	log             *logrus.Entry
+	Queue           *servicebus.Queue
+	Topic           *servicebus.Topic
+	ShutdownContext context.Context
 }
 
-func Relay(opts *cli.Options) error {
-
-	// Create new relayer instance (+ validate token & gRPC address)
-	relayCfg := &relay.Config{
-		Token:       opts.RelayToken,
-		GRPCAddress: opts.RelayGRPCAddress,
-		NumWorkers:  opts.RelayNumWorkers,
-		Timeout:     opts.RelayGRPCTimeout,
-		RelayCh:     make(chan interface{}, 1),
-		DisableTLS:  opts.RelayGRPCDisableTLS,
-		Type:        opts.RelayType,
-	}
-
-	grpcRelayer, err := relay.New(relayCfg)
-	if err != nil {
-		return errors.Wrap(err, "unable to create new gRPC relayer")
-	}
-
+func Relay(opts *cli.Options, relayCh chan interface{}, shutdownCtx context.Context) (relay.IRelayBackend, error) {
 	// Create new service
 	client, err := NewClient(opts)
 	if err != nil {
-		return errors.Wrap(err, "unable to create new azure service")
-	}
-
-	// Launch HTTP server
-	go func() {
-		if err := api.Start(opts.RelayHTTPListenAddress, opts.Version); err != nil {
-			logrus.Fatalf("unable to start API server: %s", err)
-		}
-	}()
-
-	// Launch gRPC Relayer
-	if err := grpcRelayer.StartWorkers(); err != nil {
-		return errors.Wrap(err, "unable to start gRPC relay workers")
+		return nil, errors.Wrap(err, "unable to create new azure service")
 	}
 
 	r := &Relayer{
-		Options: opts,
-		RelayCh: relayCfg.RelayCh,
-		log:     logrus.WithField("pkg", "azure/relay.go"),
+		Options:         opts,
+		RelayCh:         relayCh,
+		ShutdownContext: shutdownCtx,
+		log:             logrus.WithField("pkg", "azure/relay.go"),
 	}
 
 	if opts.Azure.Queue != "" {
 		queue, err := client.NewQueue(opts.Azure.Queue)
 		if err != nil {
-			return errors.Wrap(err, "unable to create new azure service bus queue client")
+			return nil, errors.Wrap(err, "unable to create new azure service bus queue client")
 		}
 
 		r.Queue = queue
 	} else {
 		topic, err := client.NewTopic(opts.Azure.Topic)
 		if err != nil {
-			return errors.Wrap(err, "unable to create new azure service bus topic client")
+			return nil, errors.Wrap(err, "unable to create new azure service bus topic client")
 		}
 
 		r.Topic = topic
 	}
 
-	return r.Relay()
+	return r, nil
 }
 
 // readQueue reads messages from an ASB queue
-func (r *Relayer) readQueue(ctx context.Context, handler servicebus.HandlerFunc) error {
-	defer r.Queue.Close(ctx)
+func (r *Relayer) readQueue(handler servicebus.HandlerFunc) error {
+	defer r.Queue.Close(r.ShutdownContext)
 	for {
-		if err := r.Queue.ReceiveOne(ctx, handler); err != nil {
+		if err := r.Queue.ReceiveOne(r.ShutdownContext, handler); err != nil {
+			if err == context.Canceled {
+				r.log.Info("Received shutdown signal, existing relayer")
+				return nil
+			}
+
 			return err
 		}
 	}
 }
 
 // readTopic reads messages from an ASB topic using the given subscription name
-func (r *Relayer) readTopic(ctx context.Context, handler servicebus.HandlerFunc) error {
+func (r *Relayer) readTopic(handler servicebus.HandlerFunc) error {
 	sub, err := r.Topic.NewSubscription(r.Options.Azure.Subscription)
 	if err != nil {
 		return errors.Wrap(err, "unable to create topic subscription")
 	}
 
-	defer sub.Close(ctx)
+	defer sub.Close(r.ShutdownContext)
 
 	for {
-		if err := sub.ReceiveOne(ctx, handler); err != nil {
+		if err := sub.ReceiveOne(r.ShutdownContext, handler); err != nil {
+			if err == context.Canceled {
+				r.log.Info("Received shutdown signal, existing relayer")
+				return nil
+			}
+
 			return err
 		}
 	}
@@ -115,8 +94,6 @@ func (r *Relayer) readTopic(ctx context.Context, handler servicebus.HandlerFunc)
 }
 
 func (r *Relayer) Relay() error {
-	ctx := context.Background()
-
 	if r.Queue != nil {
 		r.log.Infof("Relaying azure service bus messages from '%s' queue -> '%s'",
 			r.Options.Azure.Queue, r.Options.RelayGRPCAddress)
@@ -155,8 +132,8 @@ func (r *Relayer) Relay() error {
 	}
 
 	if r.Queue != nil {
-		return r.readQueue(ctx, handler)
+		return r.readQueue(handler)
 	}
 
-	return r.readTopic(ctx, handler)
+	return r.readTopic(handler)
 }

--- a/backends/cdc-mongo/cdc-mongo.go
+++ b/backends/cdc-mongo/cdc-mongo.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"time"
 
-	"github.com/batchcorp/plumber/cli"
-	"github.com/batchcorp/plumber/printer"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/batchcorp/plumber/cli"
+	"github.com/batchcorp/plumber/printer"
 )
 
 var (
-	errMissingDatabase = errors.New("you must specify the --database flag")
+	ErrMissingDatabase = errors.New("you must specify the --database flag")
 )
 
 type CDCMongo struct {

--- a/backends/cdc-mongo/cdc-mongo.go
+++ b/backends/cdc-mongo/cdc-mongo.go
@@ -13,8 +13,17 @@ import (
 	"github.com/batchcorp/plumber/printer"
 )
 
+const (
+	// ConnectionTimeout determines how long before a connection attempt to mongo is timed out
+	ConnectionTimeout = time.Second * 10
+
+	// ReadRetryInterval is how long to wait between read errors before plumber tries reading again
+	ReadRetryInterval = time.Second * 5
+)
+
 var (
-	ErrMissingDatabase = errors.New("you must specify the --database flag")
+	ErrMissingDatabase  = errors.New("you must specify the --database flag")
+	ErrConnectionFailed = errors.New("could not open mongo connection")
 )
 
 type CDCMongo struct {
@@ -27,12 +36,12 @@ type CDCMongo struct {
 }
 
 func NewService(opts *cli.Options) (*mongo.Client, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), ConnectionTimeout)
 	defer cancel()
 
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(opts.CDCMongo.DSN))
 	if err != nil {
-		return nil, errors.Wrap(err, "could not open mongo connection")
+		return nil, errors.Wrap(err, ErrConnectionFailed.Error())
 	}
 
 	return client, nil

--- a/backends/cdc-mongo/read.go
+++ b/backends/cdc-mongo/read.go
@@ -5,12 +5,13 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/batchcorp/plumber/cli"
-	"github.com/batchcorp/plumber/printer"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/batchcorp/plumber/cli"
+	"github.com/batchcorp/plumber/printer"
 )
 
 func Read(opts *cli.Options) error {
@@ -97,7 +98,7 @@ func (m *CDCMongo) Read() error {
 
 func validateReadOptions(opts *cli.Options) error {
 	if opts.CDCMongo.Collection != "" && opts.CDCMongo.Database == "" {
-		return errMissingDatabase
+		return ErrMissingDatabase
 	}
 	return nil
 }

--- a/backends/cdc-mongo/relay.go
+++ b/backends/cdc-mongo/relay.go
@@ -2,6 +2,7 @@ package cdc_mongo
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -83,6 +84,9 @@ func (r *Relayer) Relay() error {
 			stats.Mute("redis-pubsub-relay-producer")
 
 			r.log.Errorf("unable to read message from mongo: %s", cs.Err())
+
+			time.Sleep(ReadRetryInterval)
+			continue
 		}
 
 		stats.Incr("cdc-mongo-relay-consumer", 1)

--- a/backends/gcp-pubsub/relay.go
+++ b/backends/gcp-pubsub/relay.go
@@ -20,11 +20,11 @@ const (
 )
 
 type Relayer struct {
-	Client          *pubsub.Client
-	Options         *cli.Options
-	RelayCh         chan interface{}
-	ShutdownContext context.Context
-	log             *logrus.Entry
+	Client      *pubsub.Client
+	Options     *cli.Options
+	RelayCh     chan interface{}
+	ShutdownCtx context.Context
+	log         *logrus.Entry
 }
 
 func Relay(opts *cli.Options, relayCh chan interface{}, shutdownCtx context.Context) (relay.IRelayBackend, error) {
@@ -36,11 +36,11 @@ func Relay(opts *cli.Options, relayCh chan interface{}, shutdownCtx context.Cont
 	}
 
 	return &Relayer{
-		Client:          client,
-		Options:         opts,
-		RelayCh:         relayCh,
-		ShutdownContext: shutdownCtx,
-		log:             logrus.WithField("pkg", "gcp-pubsub/relay"),
+		Client:      client,
+		Options:     opts,
+		RelayCh:     relayCh,
+		ShutdownCtx: shutdownCtx,
+		log:         logrus.WithField("pkg", "gcp-pubsub/relay"),
 	}, nil
 }
 
@@ -75,7 +75,7 @@ func (r *Relayer) Relay() error {
 	}
 
 	for {
-		if err := sub.Receive(r.ShutdownContext, readFunc); err != nil {
+		if err := sub.Receive(r.ShutdownCtx, readFunc); err != nil {
 			if err == context.Canceled {
 				r.log.Info("Received shutdown signal, existing relayer")
 				return nil

--- a/backends/gcp-pubsub/relay.go
+++ b/backends/gcp-pubsub/relay.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"github.com/batchcorp/plumber/api"
 	"github.com/batchcorp/plumber/backends/gcp-pubsub/types"
 	"github.com/batchcorp/plumber/cli"
 	"github.com/batchcorp/plumber/relay"
@@ -21,54 +20,28 @@ const (
 )
 
 type Relayer struct {
-	Client  *pubsub.Client
-	Options *cli.Options
-	RelayCh chan interface{}
-	log     *logrus.Entry
+	Client          *pubsub.Client
+	Options         *cli.Options
+	RelayCh         chan interface{}
+	ShutdownContext context.Context
+	log             *logrus.Entry
 }
 
-func Relay(opts *cli.Options) error {
-	relayCfg := &relay.Config{
-		Token:       opts.RelayToken,
-		GRPCAddress: opts.RelayGRPCAddress,
-		NumWorkers:  opts.RelayNumWorkers,
-		Timeout:     opts.RelayGRPCTimeout,
-		RelayCh:     make(chan interface{}, 1),
-		DisableTLS:  opts.RelayGRPCDisableTLS,
-		Type:        opts.RelayType,
-	}
-
-	grpcRelayer, err := relay.New(relayCfg)
-	if err != nil {
-		return errors.Wrap(err, "unable to create new gRPC relayer")
-	}
+func Relay(opts *cli.Options, relayCh chan interface{}, shutdownCtx context.Context) (relay.IRelayBackend, error) {
 
 	// Create new service
 	client, err := NewClient(opts)
 	if err != nil {
-		return errors.Wrap(err, "unable to create new GCP pubsub service")
+		return nil, errors.Wrap(err, "unable to create new GCP pubsub service")
 	}
 
-	// Launch HTTP server
-	go func() {
-		if err := api.Start(opts.RelayHTTPListenAddress, opts.Version); err != nil {
-			logrus.Fatalf("unable to start API server: %s", err)
-		}
-	}()
-
-	// Launch gRPC Relayer
-	if err := grpcRelayer.StartWorkers(); err != nil {
-		return errors.Wrap(err, "unable to start gRPC relay workers")
-	}
-
-	r := &Relayer{
-		Client:  client,
-		Options: opts,
-		RelayCh: relayCfg.RelayCh,
-		log:     logrus.WithField("pkg", "gcp-pubsub/relay"),
-	}
-
-	return r.Relay()
+	return &Relayer{
+		Client:          client,
+		Options:         opts,
+		RelayCh:         relayCh,
+		ShutdownContext: shutdownCtx,
+		log:             logrus.WithField("pkg", "gcp-pubsub/relay"),
+	}, nil
 }
 
 func (r *Relayer) Relay() error {
@@ -102,7 +75,12 @@ func (r *Relayer) Relay() error {
 	}
 
 	for {
-		if err := sub.Receive(context.Background(), readFunc); err != nil {
+		if err := sub.Receive(r.ShutdownContext, readFunc); err != nil {
+			if err == context.Canceled {
+				r.log.Info("Received shutdown signal, existing relayer")
+				return nil
+			}
+
 			stats.Mute("gcp-relay-consumer")
 			stats.Mute("gcp-relay-producer")
 

--- a/backends/kafka/kafka.go
+++ b/backends/kafka/kafka.go
@@ -46,10 +46,6 @@ type KafkaWriter struct {
 }
 
 func NewReader(opts *cli.Options) (*KafkaReader, error) {
-	// Since you can't specify multiple environment variables with the same name, this is how brokers must be
-	// done for relay mode. The way kingpin handles this natively is by using newline separators
-	// See https://github.com/alecthomas/kingpin/issues/257
-
 	dialer := &skafka.Dialer{
 		DualStack: true,
 		Timeout:   opts.Kafka.Timeout,

--- a/backends/kafka/kafka.go
+++ b/backends/kafka/kafka.go
@@ -49,14 +49,6 @@ func NewReader(opts *cli.Options) (*KafkaReader, error) {
 	// Since you can't specify multiple environment variables with the same name, this is how brokers must be
 	// done for relay mode. The way kingpin handles this natively is by using newline separators
 	// See https://github.com/alecthomas/kingpin/issues/257
-	if len(opts.Kafka.Brokers) == 1 && strings.Contains(opts.Kafka.Brokers[0], ",") {
-		opts.Kafka.Brokers = strings.Split(opts.Kafka.Brokers[0], ",")
-	}
-
-	// Same applies for specifying multiple topics
-	if len(opts.Kafka.Topics) == 1 && strings.Contains(opts.Kafka.Topics[0], ",") {
-		opts.Kafka.Topics = strings.Split(opts.Kafka.Topics[0], ",")
-	}
 
 	dialer := &skafka.Dialer{
 		DualStack: true,

--- a/backends/kafka/relay.go
+++ b/backends/kafka/relay.go
@@ -70,7 +70,7 @@ func (r *Relayer) Relay() error {
 	for {
 		msg, err := reader.Reader.ReadMessage(r.ShutdownContext)
 		if err != nil {
-			// Shutdown cancelled, exit out of goroutine so we don't spam logs with context cancelled errors
+			// Shutdown cancelled, exit so we don't spam logs with context cancelled errors
 			if err == context.Canceled {
 				r.log.Info("Received shutdown signal, existing relayer")
 				return nil
@@ -94,5 +94,4 @@ func (r *Relayer) Relay() error {
 			Options: &types.RelayMessageOptions{},
 		}
 	}
-
 }

--- a/backends/kafka/relay.go
+++ b/backends/kafka/relay.go
@@ -19,11 +19,11 @@ const (
 )
 
 type Relayer struct {
-	Options         *cli.Options
-	RelayCh         chan interface{}
-	log             *logrus.Entry
-	Looper          *director.FreeLooper
-	ShutdownContext context.Context
+	Options     *cli.Options
+	RelayCh     chan interface{}
+	log         *logrus.Entry
+	Looper      *director.FreeLooper
+	ShutdownCtx context.Context
 }
 
 var (
@@ -37,11 +37,11 @@ func Relay(opts *cli.Options, relayCh chan interface{}, shutdownCtx context.Cont
 	}
 
 	return &Relayer{
-		Options:         opts,
-		RelayCh:         relayCh,
-		log:             logrus.WithField("pkg", "kafka/relay"),
-		Looper:          director.NewFreeLooper(director.FOREVER, make(chan error, 1)),
-		ShutdownContext: shutdownCtx,
+		Options:     opts,
+		RelayCh:     relayCh,
+		log:         logrus.WithField("pkg", "kafka/relay"),
+		Looper:      director.NewFreeLooper(director.FOREVER, make(chan error, 1)),
+		ShutdownCtx: shutdownCtx,
 	}, nil
 }
 
@@ -68,7 +68,7 @@ func (r *Relayer) Relay() error {
 	defer reader.Conn.Close()
 
 	for {
-		msg, err := reader.Reader.ReadMessage(r.ShutdownContext)
+		msg, err := reader.Reader.ReadMessage(r.ShutdownCtx)
 		if err != nil {
 			// Shutdown cancelled, exit so we don't spam logs with context cancelled errors
 			if err == context.Canceled {

--- a/backends/kafka/relay.go
+++ b/backends/kafka/relay.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"time"
 
-	"github.com/jhump/protoreflect/desc"
 	"github.com/pkg/errors"
 	"github.com/relistan/go-director"
 	"github.com/sirupsen/logrus"
 
-	"github.com/batchcorp/plumber/api"
 	"github.com/batchcorp/plumber/backends/kafka/types"
 	"github.com/batchcorp/plumber/cli"
 	"github.com/batchcorp/plumber/relay"
@@ -21,70 +19,36 @@ const (
 )
 
 type Relayer struct {
-	Options        *cli.Options
-	MsgDesc        *desc.MessageDescriptor
-	RelayCh        chan interface{}
-	log            *logrus.Entry
-	Looper         *director.FreeLooper
-	DefaultContext context.Context
-}
-
-type IKafkaRelayer interface {
-	Relay() error
+	Options         *cli.Options
+	RelayCh         chan interface{}
+	log             *logrus.Entry
+	Looper          *director.FreeLooper
+	ShutdownContext context.Context
 }
 
 var (
-	errMissingTopic = errors.New("You must specify at least one topic")
+	ErrMissingTopic = errors.New("You must specify at least one topic")
 )
 
-// Relay sets up a new Kafka relayer, starts GRPC workers and the API server
-func Relay(opts *cli.Options) error {
+// Relay sets up a new Kafka relayer
+func Relay(opts *cli.Options, relayCh chan interface{}, shutdownCtx context.Context) (relay.IRelayBackend, error) {
 	if err := validateRelayOptions(opts); err != nil {
-		return errors.Wrap(err, "unable to verify options")
+		return nil, errors.Wrap(err, "unable to verify options")
 	}
 
-	// Create new relayer instance (+ validate token & gRPC address)
-	relayCfg := &relay.Config{
-		Token:       opts.RelayToken,
-		GRPCAddress: opts.RelayGRPCAddress,
-		NumWorkers:  opts.RelayNumWorkers,
-		Timeout:     opts.RelayGRPCTimeout,
-		RelayCh:     make(chan interface{}, 1),
-		DisableTLS:  opts.RelayGRPCDisableTLS,
-		Type:        opts.RelayType,
-	}
-
-	grpcRelayer, err := relay.New(relayCfg)
-	if err != nil {
-		return errors.Wrap(err, "unable to create new gRPC relayer")
-	}
-
-	// Launch HTTP server
-	go func() {
-		if err := api.Start(opts.RelayHTTPListenAddress, opts.Version); err != nil {
-			logrus.Fatalf("unable to start API server: %s", err)
-		}
-	}()
-
-	if err := grpcRelayer.StartWorkers(); err != nil {
-		return errors.Wrap(err, "unable to start gRPC relay workers")
-	}
-
-	r := &Relayer{
-		Options:        opts,
-		RelayCh:        relayCfg.RelayCh,
-		log:            logrus.WithField("pkg", "kafka/relay"),
-		Looper:         director.NewFreeLooper(director.FOREVER, make(chan error, 1)),
-		DefaultContext: context.Background(),
-	}
-
-	return r.Relay()
+	return &Relayer{
+		Options:         opts,
+		RelayCh:         relayCh,
+		log:             logrus.WithField("pkg", "kafka/relay"),
+		Looper:          director.NewFreeLooper(director.FOREVER, make(chan error, 1)),
+		ShutdownContext: shutdownCtx,
+	}, nil
 }
 
 // validateRelayOptions ensures all required CLI options are present before initializing relay mode
 func validateRelayOptions(opts *cli.Options) error {
 	if len(opts.Kafka.Topics) == 0 {
-		return errMissingTopic
+		return ErrMissingTopic
 	}
 	return nil
 }
@@ -104,8 +68,14 @@ func (r *Relayer) Relay() error {
 	defer reader.Conn.Close()
 
 	for {
-		msg, err := reader.Reader.ReadMessage(r.DefaultContext)
+		msg, err := reader.Reader.ReadMessage(r.ShutdownContext)
 		if err != nil {
+			// Shutdown cancelled, exit out of goroutine so we don't spam logs with context cancelled errors
+			if err == context.Canceled {
+				r.log.Info("Received shutdown signal, existing relayer")
+				return nil
+			}
+
 			stats.Mute("kafka-relay-consumer")
 			stats.Mute("kafka-relay-producer")
 
@@ -124,4 +94,5 @@ func (r *Relayer) Relay() error {
 			Options: &types.RelayMessageOptions{},
 		}
 	}
+
 }

--- a/backends/mqtt/relay.go
+++ b/backends/mqtt/relay.go
@@ -19,12 +19,12 @@ import (
 )
 
 type Relayer struct {
-	Client          pahomqtt.Client
-	Options         *cli.Options
-	RelayCh         chan interface{}
-	log             *logrus.Entry
-	Looper          *director.FreeLooper
-	ShutdownContext context.Context
+	Client      pahomqtt.Client
+	Options     *cli.Options
+	RelayCh     chan interface{}
+	log         *logrus.Entry
+	Looper      *director.FreeLooper
+	ShutdownCtx context.Context
 }
 
 // Relay sets up a new MQTT relayer
@@ -39,12 +39,12 @@ func Relay(opts *cli.Options, relayCh chan interface{}, shutdownCtx context.Cont
 	}
 
 	return &Relayer{
-		Client:          client,
-		Options:         opts,
-		RelayCh:         relayCh,
-		log:             logrus.WithField("pkg", "mqtt/relay"),
-		Looper:          director.NewFreeLooper(director.FOREVER, make(chan error, 1)),
-		ShutdownContext: shutdownCtx,
+		Client:      client,
+		Options:     opts,
+		RelayCh:     relayCh,
+		log:         logrus.WithField("pkg", "mqtt/relay"),
+		Looper:      director.NewFreeLooper(director.FOREVER, make(chan error, 1)),
+		ShutdownCtx: shutdownCtx,
 	}, nil
 }
 
@@ -113,7 +113,7 @@ func (r *Relayer) Relay() error {
 
 	for {
 		select {
-		case <-r.ShutdownContext.Done():
+		case <-r.ShutdownCtx.Done():
 			r.log.Info("Received shutdown signal, existing relayer")
 			return nil
 		default:

--- a/backends/mqtt/relay.go
+++ b/backends/mqtt/relay.go
@@ -8,79 +8,44 @@ import (
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	pahomqtt "github.com/eclipse/paho.mqtt.golang"
 
-	"github.com/batchcorp/plumber/api"
+	"github.com/pkg/errors"
+	"github.com/relistan/go-director"
+	"github.com/sirupsen/logrus"
+
 	"github.com/batchcorp/plumber/backends/mqtt/types"
 	"github.com/batchcorp/plumber/cli"
 	"github.com/batchcorp/plumber/relay"
 	"github.com/batchcorp/plumber/stats"
-	"github.com/jhump/protoreflect/desc"
-	"github.com/pkg/errors"
-	"github.com/relistan/go-director"
-	"github.com/sirupsen/logrus"
 )
 
 type Relayer struct {
-	Client  pahomqtt.Client
-	Options *cli.Options
-	MsgDesc *desc.MessageDescriptor
-	RelayCh chan interface{}
-	log     *logrus.Entry
-	Looper  *director.FreeLooper
-	Context context.Context
+	Client          pahomqtt.Client
+	Options         *cli.Options
+	RelayCh         chan interface{}
+	log             *logrus.Entry
+	Looper          *director.FreeLooper
+	ShutdownContext context.Context
 }
 
-type IMQTTRelayer interface {
-	Relay() error
-}
-
-// Relay sets up a new MQTT relayer, starts GRPC workers and the API server
-func Relay(opts *cli.Options) error {
+// Relay sets up a new MQTT relayer
+func Relay(opts *cli.Options, relayCh chan interface{}, shutdownCtx context.Context) (relay.IRelayBackend, error) {
 	if err := validateRelayOptions(opts); err != nil {
-		return errors.Wrap(err, "unable to verify options")
-	}
-
-	// Create new relayer instance (+ validate token & gRPC address)
-	relayCfg := &relay.Config{
-		Token:       opts.RelayToken,
-		GRPCAddress: opts.RelayGRPCAddress,
-		NumWorkers:  opts.RelayNumWorkers,
-		Timeout:     opts.RelayGRPCTimeout,
-		RelayCh:     make(chan interface{}, 1),
-		DisableTLS:  opts.RelayGRPCDisableTLS,
-		Type:        opts.RelayType,
-	}
-
-	grpcRelayer, err := relay.New(relayCfg)
-	if err != nil {
-		return errors.Wrap(err, "unable to create new gRPC relayer")
-	}
-
-	// Launch HTTP server
-	go func() {
-		if err := api.Start(opts.RelayHTTPListenAddress, opts.Version); err != nil {
-			logrus.Fatalf("unable to start API server: %s", err)
-		}
-	}()
-
-	if err := grpcRelayer.StartWorkers(); err != nil {
-		return errors.Wrap(err, "unable to start gRPC relay workers")
+		return nil, errors.Wrap(err, "unable to verify options")
 	}
 
 	client, err := connect(opts)
 	if err != nil {
-		return errors.Wrap(err, "unable to create client")
+		return nil, errors.Wrap(err, "unable to create client")
 	}
 
-	r := &Relayer{
-		Client:  client,
-		Options: opts,
-		RelayCh: relayCfg.RelayCh,
-		log:     logrus.WithField("pkg", "mqtt/relay"),
-		Looper:  director.NewFreeLooper(director.FOREVER, make(chan error, 1)),
-		Context: context.Background(),
-	}
-
-	return r.Relay()
+	return &Relayer{
+		Client:          client,
+		Options:         opts,
+		RelayCh:         relayCh,
+		log:             logrus.WithField("pkg", "mqtt/relay"),
+		Looper:          director.NewFreeLooper(director.FOREVER, make(chan error, 1)),
+		ShutdownContext: shutdownCtx,
+	}, nil
 }
 
 // validateRelayOptions ensures all required CLI options are present before initializing relay mode
@@ -148,8 +113,11 @@ func (r *Relayer) Relay() error {
 
 	for {
 		select {
-		case <-r.Context.Done():
+		case <-r.ShutdownContext.Done():
+			r.log.Info("Received shutdown signal, existing relayer")
 			return nil
+		default:
+			// noop
 		}
 	}
 

--- a/backends/nsq/relay.go
+++ b/backends/nsq/relay.go
@@ -14,10 +14,10 @@ import (
 )
 
 type Relayer struct {
-	Options         *cli.Options
-	RelayCh         chan interface{}
-	log             *logrus.Entry
-	ShutdownContext context.Context
+	Options     *cli.Options
+	RelayCh     chan interface{}
+	log         *logrus.Entry
+	ShutdownCtx context.Context
 }
 
 func Relay(opts *cli.Options, relayCh chan interface{}, shutdownCtx context.Context) (relay.IRelayBackend, error) {
@@ -26,10 +26,10 @@ func Relay(opts *cli.Options, relayCh chan interface{}, shutdownCtx context.Cont
 	}
 
 	return &Relayer{
-		Options:         opts,
-		RelayCh:         relayCh,
-		log:             logrus.WithField("pkg", "nsq/relay"),
-		ShutdownContext: shutdownCtx,
+		Options:     opts,
+		RelayCh:     relayCh,
+		log:         logrus.WithField("pkg", "nsq/relay"),
+		ShutdownCtx: shutdownCtx,
 	}, nil
 }
 
@@ -90,7 +90,7 @@ func (r *Relayer) Relay() error {
 
 	for {
 		select {
-		case <-r.ShutdownContext.Done():
+		case <-r.ShutdownCtx.Done():
 			r.log.Info("Received shutdown signal, existing relayer")
 			return nil
 		default:

--- a/backends/rabbitmq/relay.go
+++ b/backends/rabbitmq/relay.go
@@ -3,18 +3,16 @@ package rabbitmq
 import (
 	"context"
 
-	"github.com/batchcorp/plumber/backends/rabbitmq/types"
-	"github.com/batchcorp/plumber/stats"
-
 	"github.com/pkg/errors"
 	"github.com/relistan/go-director"
 	"github.com/sirupsen/logrus"
 	"github.com/streadway/amqp"
 
-	"github.com/batchcorp/rabbit"
-
+	"github.com/batchcorp/plumber/backends/rabbitmq/types"
 	"github.com/batchcorp/plumber/cli"
 	"github.com/batchcorp/plumber/relay"
+	"github.com/batchcorp/plumber/stats"
+	"github.com/batchcorp/rabbit"
 )
 
 type Relayer struct {

--- a/backends/rabbitmq/relay.go
+++ b/backends/rabbitmq/relay.go
@@ -2,76 +2,42 @@ package rabbitmq
 
 import (
 	"context"
+
 	"github.com/batchcorp/plumber/backends/rabbitmq/types"
 	"github.com/batchcorp/plumber/stats"
 
-	"github.com/batchcorp/rabbit"
-	"github.com/jhump/protoreflect/desc"
 	"github.com/pkg/errors"
 	"github.com/relistan/go-director"
 	"github.com/sirupsen/logrus"
 	"github.com/streadway/amqp"
 
-	"github.com/batchcorp/plumber/api"
+	"github.com/batchcorp/rabbit"
+
 	"github.com/batchcorp/plumber/cli"
 	"github.com/batchcorp/plumber/relay"
 )
 
 type Relayer struct {
-	Options        *cli.Options
-	Channel        *amqp.Channel
-	MsgDesc        *desc.MessageDescriptor
-	RelayCh        chan interface{}
-	log            *logrus.Entry
-	Looper         *director.FreeLooper
-	DefaultContext context.Context
+	Options         *cli.Options
+	Channel         *amqp.Channel
+	RelayCh         chan interface{}
+	log             *logrus.Entry
+	Looper          *director.FreeLooper
+	ShutdownContext context.Context
 }
 
-func Relay(opts *cli.Options) error {
+func Relay(opts *cli.Options, relayCh chan interface{}, shutdownCtx context.Context) (relay.IRelayBackend, error) {
 	if err := validateRelayOptions(opts); err != nil {
-		return errors.Wrap(err, "unable to verify options")
+		return nil, errors.Wrap(err, "unable to verify options")
 	}
 
-	// TODO: move this up the chain?
-	ctx := context.Background()
-
-	// Create new relayer instance (+ validate token & gRPC address)
-	relayCfg := &relay.Config{
-		Token:       opts.RelayToken,
-		GRPCAddress: opts.RelayGRPCAddress,
-		NumWorkers:  opts.RelayNumWorkers,
-		Timeout:     opts.RelayGRPCTimeout,
-		RelayCh:     make(chan interface{}, 1),
-		DisableTLS:  opts.RelayGRPCDisableTLS,
-		Type:        opts.RelayType,
-	}
-
-	grpcRelayer, err := relay.New(relayCfg)
-	if err != nil {
-		return errors.Wrap(err, "unable to create new gRPC relayer")
-	}
-
-	// Launch HTTP server
-	go func() {
-		if err := api.Start(opts.RelayHTTPListenAddress, opts.Version); err != nil {
-			logrus.Fatalf("unable to start API server: %s", err)
-		}
-	}()
-
-	// Launch gRPC Relayer
-	if err := grpcRelayer.StartWorkers(); err != nil {
-		return errors.Wrap(err, "unable to start gRPC relay workers")
-	}
-
-	r := &Relayer{
-		Options:        opts,
-		RelayCh:        relayCfg.RelayCh,
-		log:            logrus.WithField("pkg", "rabbitmq/relay"),
-		Looper:         director.NewFreeLooper(director.FOREVER, make(chan error, 1)),
-		DefaultContext: ctx,
-	}
-
-	return r.Relay()
+	return &Relayer{
+		Options:         opts,
+		RelayCh:         relayCh,
+		log:             logrus.WithField("pkg", "rabbitmq/relay"),
+		Looper:          director.NewFreeLooper(director.FOREVER, make(chan error, 1)),
+		ShutdownContext: shutdownCtx,
+	}, nil
 }
 
 func validateRelayOptions(opts *cli.Options) error {
@@ -114,9 +80,7 @@ func (r *Relayer) Relay() error {
 
 	defer rmq.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
-
-	go rmq.Consume(ctx, errCh, func(msg amqp.Delivery) error {
+	go rmq.Consume(r.ShutdownContext, errCh, func(msg amqp.Delivery) error {
 		if msg.Body == nil {
 			// Ignore empty messages
 			// this will also prevent log spam if a queue goes missing
@@ -138,9 +102,13 @@ func (r *Relayer) Relay() error {
 		select {
 		case errRabbit := <-errCh:
 			r.log.Errorf("runFunc ran into an error: %s", errRabbit.Error.Error())
+		case <-r.ShutdownContext.Done():
+			r.log.Info("Received shutdown signal, existing relayer")
+			return nil
+		default:
+			// noop
 		}
 	}
 
-	cancel()
 	return nil
 }

--- a/backends/rstreams/relay.go
+++ b/backends/rstreams/relay.go
@@ -21,12 +21,12 @@ const (
 )
 
 type Relayer struct {
-	Client          *redis.Client
-	Options         *cli.Options
-	RelayCh         chan interface{}
-	log             *logrus.Entry
-	Looper          *director.FreeLooper
-	ShutdownContext context.Context
+	Client      *redis.Client
+	Options     *cli.Options
+	RelayCh     chan interface{}
+	log         *logrus.Entry
+	Looper      *director.FreeLooper
+	ShutdownCtx context.Context
 }
 
 var (
@@ -45,16 +45,16 @@ func Relay(opts *cli.Options, relayCh chan interface{}, shutdownCtx context.Cont
 	}
 
 	r := &Relayer{
-		Client:          client,
-		Options:         opts,
-		RelayCh:         relayCh,
-		log:             logrus.WithField("pkg", "rstreams/relay"),
-		Looper:          director.NewFreeLooper(director.FOREVER, make(chan error, 1)),
-		ShutdownContext: shutdownCtx,
+		Client:      client,
+		Options:     opts,
+		RelayCh:     relayCh,
+		log:         logrus.WithField("pkg", "rstreams/relay"),
+		Looper:      director.NewFreeLooper(director.FOREVER, make(chan error, 1)),
+		ShutdownCtx: shutdownCtx,
 	}
 
 	// Create consumer group (and stream) for each stream
-	if err := CreateConsumerGroups(r.ShutdownContext, client, r.Options.RedisStreams); err != nil {
+	if err := CreateConsumerGroups(r.ShutdownCtx, client, r.Options.RedisStreams); err != nil {
 		return nil, fmt.Errorf("unable to create consumer group(s): %s", err)
 	}
 
@@ -87,7 +87,7 @@ func (r *Relayer) Relay() error {
 	streams := generateStreams(r.Options.RedisStreams.Streams)
 
 	for {
-		streamsResult, err := r.Client.XReadGroup(r.ShutdownContext, &redis.XReadGroupArgs{
+		streamsResult, err := r.Client.XReadGroup(r.ShutdownCtx, &redis.XReadGroupArgs{
 			Group:    r.Options.RedisStreams.ConsumerGroup,
 			Consumer: r.Options.RedisStreams.ConsumerName,
 			Streams:  streams,

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -211,19 +211,19 @@ func Handle(cliArgs []string) (string, *Options, error) {
 // environment variables in kingpin are newline delimited for some odd reason
 // See https://github.com/alecthomas/kingpin/issues/257
 func convertSliceArgs(opts *Options) {
-	if len(opts.RedisPubSub.Channels) > 0 {
+	if len(opts.RedisPubSub.Channels) == 1 {
 		opts.RedisPubSub.Channels = strings.Split(opts.RedisPubSub.Channels[0], ",")
 	}
 
-	if len(opts.RedisStreams.Streams) > 0 {
+	if len(opts.RedisStreams.Streams) == 1 {
 		opts.RedisStreams.Streams = strings.Split(opts.RedisStreams.Streams[0], ",")
 	}
 
-	if len(opts.Kafka.Brokers) > 0 && strings.Contains(opts.Kafka.Brokers[0], ",") {
+	if len(opts.Kafka.Brokers) == 1 && strings.Contains(opts.Kafka.Brokers[0], ",") {
 		opts.Kafka.Brokers = strings.Split(opts.Kafka.Brokers[0], ",")
 	}
 
-	if len(opts.Kafka.Topics) > 0 && strings.Contains(opts.Kafka.Topics[0], ",") {
+	if len(opts.Kafka.Topics) == 1 && strings.Contains(opts.Kafka.Topics[0], ",") {
 		opts.Kafka.Topics = strings.Split(opts.Kafka.Topics[0], ",")
 	}
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -207,13 +207,24 @@ func Handle(cliArgs []string) (string, *Options, error) {
 	return cmd, opts, err
 }
 
+// convertSliceArgs splits up comma delimited flags into a slice. We do this because slice argument
+// environment variables in kingpin are newline delimited for some odd reason
+// See https://github.com/alecthomas/kingpin/issues/257
 func convertSliceArgs(opts *Options) {
-	if len(opts.RedisPubSub.Channels) != 0 {
+	if len(opts.RedisPubSub.Channels) > 0 {
 		opts.RedisPubSub.Channels = strings.Split(opts.RedisPubSub.Channels[0], ",")
 	}
 
-	if len(opts.RedisStreams.Streams) != 0 {
+	if len(opts.RedisStreams.Streams) > 0 {
 		opts.RedisStreams.Streams = strings.Split(opts.RedisStreams.Streams[0], ",")
+	}
+
+	if len(opts.Kafka.Brokers) > 0 && strings.Contains(opts.Kafka.Brokers[0], ",") {
+		opts.Kafka.Brokers = strings.Split(opts.Kafka.Brokers[0], ",")
+	}
+
+	if len(opts.Kafka.Topics) > 0 && strings.Contains(opts.Kafka.Topics[0], ",") {
+		opts.Kafka.Topics = strings.Split(opts.Kafka.Topics[0], ",")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -6,13 +6,11 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/batchcorp/plumber/plumber"
-
+	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh/terminal"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/batchcorp/plumber/cli"
+	"github.com/batchcorp/plumber/plumber"
 	"github.com/batchcorp/plumber/printer"
 	"github.com/batchcorp/plumber/stats"
 )

--- a/main.go
+++ b/main.go
@@ -34,14 +34,15 @@ func main() {
 	mainCtx, mainShutdownFunc := context.WithCancel(context.Background())
 
 	// We only want to intercept these in relay mode
-	if strings.HasPrefix("cmd", "relay") {
+	if strings.HasPrefix(cmd, "relay") {
+		logrus.Debug("Intercepting signals")
 		c := make(chan os.Signal, 1)
 		signal.Notify(c, os.Interrupt)
 		signal.Notify(c, syscall.SIGTERM)
 
 		go func() {
 			signal := <-c
-			logrus.Infof("received system call: %+v", signal)
+			logrus.Debugf("Received system call: %+v", signal)
 
 			serviceShutdownFunc()
 		}()
@@ -59,11 +60,11 @@ func main() {
 	}
 
 	p, err := plumber.New(&plumber.Config{
-		ServiceShutdownContext: serviceCtx,
-		MainShutdownFunc:       mainShutdownFunc,
-		MainShutdownContext:    mainCtx,
-		Cmd:                    cmd,
-		Options:                opts,
+		ServiceShutdownCtx: serviceCtx,
+		MainShutdownFunc:   mainShutdownFunc,
+		MainShutdownCtx:    mainCtx,
+		Cmd:                cmd,
+		Options:            opts,
 	})
 
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -1,32 +1,17 @@
 package main
 
 import (
-	"fmt"
+	"context"
 	"os"
-	"strings"
+	"os/signal"
+	"syscall"
+
+	"github.com/batchcorp/plumber/plumber"
 
 	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/batchcorp/plumber/backends/activemq"
-	awssns "github.com/batchcorp/plumber/backends/aws-sns"
-	awssqs "github.com/batchcorp/plumber/backends/aws-sqs"
-	"github.com/batchcorp/plumber/backends/azure"
-	azureEventhub "github.com/batchcorp/plumber/backends/azure-eventhub"
-	"github.com/batchcorp/plumber/backends/batch"
-	cdcMongo "github.com/batchcorp/plumber/backends/cdc-mongo"
-	cdcPostgres "github.com/batchcorp/plumber/backends/cdc-postgres"
-	gcppubsub "github.com/batchcorp/plumber/backends/gcp-pubsub"
-	"github.com/batchcorp/plumber/backends/kafka"
-	"github.com/batchcorp/plumber/backends/mqtt"
-	"github.com/batchcorp/plumber/backends/nats"
-	natsStreaming "github.com/batchcorp/plumber/backends/nats-streaming"
-	"github.com/batchcorp/plumber/backends/nsq"
-	"github.com/batchcorp/plumber/backends/pulsar"
-	"github.com/batchcorp/plumber/backends/rabbitmq"
-	"github.com/batchcorp/plumber/backends/rpubsub"
-	"github.com/batchcorp/plumber/backends/rstreams"
 	"github.com/batchcorp/plumber/cli"
 	"github.com/batchcorp/plumber/printer"
 	"github.com/batchcorp/plumber/stats"
@@ -46,6 +31,20 @@ func main() {
 		logrus.SetLevel(logrus.ErrorLevel)
 	}
 
+	serviceCtx, serviceShutdownFunc := context.WithCancel(context.Background())
+	mainCtx, mainShutdownFunc := context.WithCancel(context.Background())
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, syscall.SIGTERM)
+
+	go func() {
+		signal := <-c
+		logrus.Infof("received system call: %+v", signal)
+
+		serviceShutdownFunc()
+	}()
+
 	if opts.Stats {
 		stats.Start(opts.StatsReportInterval)
 	}
@@ -57,261 +56,17 @@ func main() {
 		printer.PrintLogo()
 	}
 
-	if strings.HasPrefix(cmd, "relay") {
-		printer.PrintRelayOptions(cmd, opts)
-	}
-
-	if strings.HasPrefix(cmd, "batch") {
-		parseBatchCmd(cmd, opts)
-		return
-	}
-
-	parseCmd(cmd, opts)
-}
-
-func parseCmd(cmd string, opts *cli.Options) {
-	var err error
-
-	switch {
-	case strings.HasPrefix(cmd, "read"):
-		err = parseCmdRead(cmd, opts)
-	case strings.HasPrefix(cmd, "write"):
-		err = parseCmdWrite(cmd, opts)
-	case strings.HasPrefix(cmd, "relay"):
-		err = parseCmdRelay(cmd, opts)
-	case strings.HasPrefix(cmd, "dynamic"):
-		err = parseCmdDynamic(cmd, opts)
-	default:
-		logrus.Fatalf("unrecognized command: %s", cmd)
-	}
+	p, err := plumber.New(&plumber.Config{
+		ServiceShutdownContext: serviceCtx,
+		MainShutdownFunc:       mainShutdownFunc,
+		MainShutdownContext:    mainCtx,
+		Cmd:                    cmd,
+		Options:                opts,
+	})
 
 	if err != nil {
-		logrus.Fatalf("Unable to complete command: %s", err)
-	}
-}
-
-func parseCmdRead(cmd string, opts *cli.Options) error {
-	switch cmd {
-	case "read rabbit":
-		return rabbitmq.Read(opts)
-	case "read kafka":
-		return kafka.Read(opts)
-	case "read gcp-pubsub":
-		return gcppubsub.Read(opts)
-	case "read mqtt":
-		return mqtt.Read(opts)
-	case "read aws-sqs":
-		return awssqs.Read(opts)
-	case "read activemq":
-		return activemq.Read(opts)
-	case "read azure":
-		return azure.Read(opts)
-	case "read azure-eventhub":
-		return azureEventhub.Read(opts)
-	case "read nats":
-		return nats.Read(opts)
-	case "read nats-streaming":
-		return natsStreaming.Read(opts)
-	case "read redis-pubsub":
-		return rpubsub.Read(opts)
-	case "read redis-streams":
-		return rstreams.Read(opts)
-	case "read cdc-mongo":
-		return cdcMongo.Read(opts)
-	case "read cdc-postgres":
-		return cdcPostgres.Read(opts)
-	case "read pulsar":
-		return pulsar.Read(opts)
-	case "read nsq":
-		return nsq.Read(opts)
-	default:
-		return fmt.Errorf("unrecognized command: %s", cmd)
-	}
-}
-
-func parseCmdWrite(cmd string, opts *cli.Options) error {
-	switch cmd {
-	case "write rabbit":
-		return rabbitmq.Write(opts)
-	case "write kafka":
-		return kafka.Write(opts)
-	case "write gcp-pubsub":
-		return gcppubsub.Write(opts)
-	case "write mqtt":
-		return mqtt.Write(opts)
-	case "write aws-sqs":
-		return awssqs.Write(opts)
-	case "write activemq":
-		return activemq.Write(opts)
-	case "write aws-sns":
-		return awssns.Write(opts)
-	case "write azure":
-		return azure.Write(opts)
-	case "write azure-eventhub":
-		return azureEventhub.Write(opts)
-	case "write nats":
-		return nats.Write(opts)
-	case "write nats-streaming":
-		return natsStreaming.Write(opts)
-	case "write redis-pubsub":
-		return rpubsub.Write(opts)
-	case "write redis-streams":
-		return rstreams.Write(opts)
-	case "write pulsar":
-		return pulsar.Write(opts)
-	case "write nsq":
-		return nsq.Write(opts)
-	default:
-		return fmt.Errorf("unrecognized command: %s", cmd)
-	}
-}
-
-func parseCmdRelay(cmd string, opts *cli.Options) error {
-	switch cmd {
-	case "relay rabbit":
-		opts.RelayType = "rabbit"
-		return rabbitmq.Relay(opts)
-	case "relay kafka":
-		opts.RelayType = "kafka"
-		return kafka.Relay(opts)
-	case "relay gcp-pubsub":
-		opts.RelayType = "gcp-pubsub"
-		return gcppubsub.Relay(opts)
-	case "relay mqtt":
-		opts.RelayType = "mqtt"
-		return mqtt.Relay(opts)
-	case "relay aws-sqs":
-		opts.RelayType = "aws-sqs"
-		return awssqs.Relay(opts)
-	case "relay azure":
-		opts.RelayType = "azure"
-		return azure.Relay(opts)
-	case "relay cdc-postgres":
-		opts.RelayType = "cdc-postgres"
-		return cdcPostgres.Relay(opts)
-	case "relay cdc-mongo":
-		opts.RelayType = "cdc-mongo"
-		return cdcMongo.Relay(opts)
-	case "relay redis-pubsub":
-		opts.RelayType = "redis-pubsub"
-		return rpubsub.Relay(opts)
-	case "relay redis-streams":
-		opts.RelayType = "redis-streams"
-		return rstreams.Relay(opts)
-	case "relay nsq":
-		opts.RelayType = "nsq"
-		return nsq.Relay(opts)
-	// Relay (via env vars)
-	case "relay":
-		return ProcessRelayFlags(opts)
+		logrus.Fatal(err)
 	}
 
-	return fmt.Errorf("unrecognized command: %s", cmd)
-}
-
-func parseCmdDynamic(cmd string, opts *cli.Options) error {
-	parsedCmd := strings.Split(cmd, " ")
-	switch parsedCmd[1] {
-	case "kafka":
-		return kafka.Dynamic(opts)
-	case "rabbit":
-		return rabbitmq.Dynamic(opts)
-	case "mqtt":
-		return mqtt.Dynamic(opts)
-	case "redis-pubsub":
-		return rpubsub.Dynamic(opts)
-	case "redis-streams":
-		return rstreams.Dynamic(opts)
-	case "nats":
-		return nats.Dynamic(opts)
-	case "nats-streaming":
-		return natsStreaming.Dynamic(opts)
-	case "activemq":
-		return activemq.Dynamic(opts)
-	case "gcp-pubsub":
-		return gcppubsub.Dynamic(opts)
-	case "aws-sqs":
-		return awssqs.Dynamic(opts)
-	case "aws-sns":
-		return awssns.Dynamic(opts)
-	case "azure":
-		return azure.Dynamic(opts)
-	case "azure-eventhub":
-		return azureEventhub.Dynamic(opts)
-	}
-
-	return fmt.Errorf("unrecognized command: %s", cmd)
-}
-
-func ProcessRelayFlags(opts *cli.Options) error {
-	var err error
-
-	switch opts.RelayType {
-	case "kafka":
-		err = kafka.Relay(opts)
-	case "gcp-pubsub":
-		err = gcppubsub.Relay(opts)
-	case "mqtt":
-		err = mqtt.Relay(opts)
-	case "aws-sqs":
-		err = awssqs.Relay(opts)
-	case "rabbit":
-		err = rabbitmq.Relay(opts)
-	case "azure":
-		err = azure.Relay(opts)
-	case "cdc-mongo":
-		err = cdcMongo.Relay(opts)
-	case "redis-pubsub":
-		err = rpubsub.Relay(opts)
-	case "redis-streams":
-		err = rstreams.Relay(opts)
-	case "cdc-postgres":
-		err = cdcPostgres.Relay(opts)
-	case "nsq":
-		err = nsq.Relay(opts)
-	default:
-		err = fmt.Errorf("unsupported messaging system '%s'", opts.RelayType)
-	}
-
-	return err
-}
-
-// parseBatchCmd handles all commands related to Batch.sh API
-func parseBatchCmd(cmd string, opts *cli.Options) {
-	var err error
-
-	b := batch.New(opts)
-
-	commands := strings.Split(cmd, " ")
-
-	switch {
-	case cmd == "batch login":
-		err = b.Login()
-	case cmd == "batch logout":
-		err = b.Logout()
-	case cmd == "batch list collection":
-		err = b.ListCollections()
-	case cmd == "batch create collection":
-		err = b.CreateCollection()
-	case cmd == "batch list destination":
-		err = b.ListDestinations()
-	case strings.HasPrefix(cmd, "batch create destination"):
-		err = b.CreateDestination(commands[3])
-	case cmd == "batch list schema":
-		err = b.ListSchemas()
-	case cmd == "batch list replay":
-		err = b.ListReplays()
-	case cmd == "batch create replay":
-		err = b.CreateReplay()
-	case cmd == "batch archive replay":
-		err = b.ArchiveReplay()
-	case cmd == "batch search":
-		err = b.SearchCollection()
-	default:
-		logrus.Fatalf("unrecognized command: %s", cmd)
-	}
-
-	if err != nil {
-		logrus.Fatalf("Unable to complete command: %s", err)
-	}
+	p.Run()
 }

--- a/plumber/parse.go
+++ b/plumber/parse.go
@@ -114,37 +114,37 @@ func (p *Plumber) parseCmdRelay() error {
 	switch p.Cmd {
 	case "relay rabbit":
 		p.Options.RelayType = "rabbit"
-		rr, err = rabbitmq.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = rabbitmq.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "relay kafka":
 		p.Options.RelayType = "kafka"
-		rr, err = kafka.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = kafka.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "relay gcp-pubsub":
 		p.Options.RelayType = "gcp-pubsub"
-		rr, err = gcpPubSub.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = gcpPubSub.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "relay mqtt":
 		p.Options.RelayType = "mqtt"
-		rr, err = mqtt.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = mqtt.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "relay aws-sqs":
 		p.Options.RelayType = "aws-sqs"
-		rr, err = awssqs.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = awssqs.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "relay azure":
 		p.Options.RelayType = "azure"
-		rr, err = azure.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = azure.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "relay cdc-postgres":
 		p.Options.RelayType = "cdc-postgres"
-		rr, err = cdcPostgres.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = cdcPostgres.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "relay cdc-mongo":
 		p.Options.RelayType = "cdc-mongo"
-		rr, err = cdcMongo.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = cdcMongo.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "relay redis-pubsub":
 		p.Options.RelayType = "redis-pubsub"
-		rr, err = rpubsub.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = rpubsub.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "relay redis-streams":
 		p.Options.RelayType = "redis-streams"
-		rr, err = rstreams.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = rstreams.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "relay nsq":
 		p.Options.RelayType = "nsq"
-		rr, err = nsq.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = nsq.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "relay": // Relay (via env vars)
 		rr, err = p.processRelayFlags()
 	default:
@@ -163,7 +163,7 @@ func (p *Plumber) parseCmdRelay() error {
 		return err
 	}
 
-	<-p.MainShutdownContext.Done()
+	<-p.MainShutdownCtx.Done()
 
 	p.log.Info("Application exiting")
 
@@ -177,27 +177,27 @@ func (p *Plumber) processRelayFlags() (relay.IRelayBackend, error) {
 
 	switch p.Options.RelayType {
 	case "kafka":
-		rr, err = kafka.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = kafka.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "gcp-pubsub":
-		rr, err = gcpPubSub.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = gcpPubSub.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "mqtt":
-		rr, err = mqtt.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = mqtt.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "aws-sqs":
-		rr, err = awssqs.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = awssqs.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "rabbit":
-		rr, err = rabbitmq.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = rabbitmq.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "azure":
-		rr, err = azure.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = azure.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "cdc-mongo":
-		rr, err = cdcMongo.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = cdcMongo.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "redis-pubsub":
-		rr, err = rpubsub.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = rpubsub.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "redis-streams":
-		rr, err = rstreams.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = rstreams.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "cdc-postgres":
-		rr, err = cdcPostgres.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = cdcPostgres.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	case "nsq":
-		rr, err = nsq.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+		rr, err = nsq.Relay(p.Options, p.RelayCh, p.ServiceShutdownCtx)
 	default:
 		err = fmt.Errorf("unsupported messaging system '%s'", p.Options.RelayType)
 	}

--- a/plumber/parse.go
+++ b/plumber/parse.go
@@ -1,0 +1,274 @@
+package plumber
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/batchcorp/plumber/relay"
+
+	"github.com/batchcorp/plumber/backends/activemq"
+	awssns "github.com/batchcorp/plumber/backends/aws-sns"
+	awssqs "github.com/batchcorp/plumber/backends/aws-sqs"
+	"github.com/batchcorp/plumber/backends/azure"
+	azureEventhub "github.com/batchcorp/plumber/backends/azure-eventhub"
+	"github.com/batchcorp/plumber/backends/batch"
+	cdcMongo "github.com/batchcorp/plumber/backends/cdc-mongo"
+	cdcPostgres "github.com/batchcorp/plumber/backends/cdc-postgres"
+	gcpPubSub "github.com/batchcorp/plumber/backends/gcp-pubsub"
+	"github.com/batchcorp/plumber/backends/kafka"
+	"github.com/batchcorp/plumber/backends/mqtt"
+	"github.com/batchcorp/plumber/backends/nats"
+	natsStreaming "github.com/batchcorp/plumber/backends/nats-streaming"
+	"github.com/batchcorp/plumber/backends/nsq"
+	"github.com/batchcorp/plumber/backends/pulsar"
+	"github.com/batchcorp/plumber/backends/rabbitmq"
+	"github.com/batchcorp/plumber/backends/rpubsub"
+	"github.com/batchcorp/plumber/backends/rstreams"
+)
+
+// parseCmdRead handles read mode
+func (p *Plumber) parseCmdRead() error {
+	switch p.Cmd {
+	case "read rabbit":
+		return rabbitmq.Read(p.Options)
+	case "read kafka":
+		return kafka.Read(p.Options)
+	case "read gcp-pubsub":
+		return gcpPubSub.Read(p.Options)
+	case "read mqtt":
+		return mqtt.Read(p.Options)
+	case "read aws-sqs":
+		return awssqs.Read(p.Options)
+	case "read activemq":
+		return activemq.Read(p.Options)
+	case "read azure":
+		return azure.Read(p.Options)
+	case "read azure-eventhub":
+		return azureEventhub.Read(p.Options)
+	case "read nats":
+		return nats.Read(p.Options)
+	case "read nats-streaming":
+		return natsStreaming.Read(p.Options)
+	case "read redis-pubsub":
+		return rpubsub.Read(p.Options)
+	case "read redis-streams":
+		return rstreams.Read(p.Options)
+	case "read cdc-mongo":
+		return cdcMongo.Read(p.Options)
+	case "read cdc-postgres":
+		return cdcPostgres.Read(p.Options)
+	case "read pulsar":
+		return pulsar.Read(p.Options)
+	case "read nsq":
+		return nsq.Read(p.Options)
+	default:
+		return fmt.Errorf("unrecognized command: %s", p.Cmd)
+	}
+}
+
+// parseCmdWrite handles write mode
+func (p *Plumber) parseCmdWrite() error {
+	switch p.Cmd {
+	case "write rabbit":
+		return rabbitmq.Write(p.Options)
+	case "write kafka":
+		return kafka.Write(p.Options)
+	case "write gcp-pubsub":
+		return gcpPubSub.Write(p.Options)
+	case "write mqtt":
+		return mqtt.Write(p.Options)
+	case "write aws-sqs":
+		return awssqs.Write(p.Options)
+	case "write activemq":
+		return activemq.Write(p.Options)
+	case "write aws-sns":
+		return awssns.Write(p.Options)
+	case "write azure":
+		return azure.Write(p.Options)
+	case "write azure-eventhub":
+		return azureEventhub.Write(p.Options)
+	case "write nats":
+		return nats.Write(p.Options)
+	case "write nats-streaming":
+		return natsStreaming.Write(p.Options)
+	case "write redis-pubsub":
+		return rpubsub.Write(p.Options)
+	case "write redis-streams":
+		return rstreams.Write(p.Options)
+	case "write pulsar":
+		return pulsar.Write(p.Options)
+	case "write nsq":
+		return nsq.Write(p.Options)
+	default:
+		return fmt.Errorf("unrecognized command: %s", p.Cmd)
+	}
+}
+
+// parseCmdRelay handles CLI relay mode. Container/envar mode is handled by processRelayFlags
+func (p *Plumber) parseCmdRelay() error {
+	var rr relay.IRelayBackend
+	var err error
+
+	switch p.Cmd {
+	case "relay rabbit":
+		p.Options.RelayType = "rabbit"
+		rr, err = rabbitmq.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "relay kafka":
+		p.Options.RelayType = "kafka"
+		rr, err = kafka.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "relay gcp-pubsub":
+		p.Options.RelayType = "gcp-pubsub"
+		rr, err = gcpPubSub.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "relay mqtt":
+		p.Options.RelayType = "mqtt"
+		rr, err = mqtt.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "relay aws-sqs":
+		p.Options.RelayType = "aws-sqs"
+		rr, err = awssqs.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "relay azure":
+		p.Options.RelayType = "azure"
+		rr, err = azure.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "relay cdc-postgres":
+		p.Options.RelayType = "cdc-postgres"
+		rr, err = cdcPostgres.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "relay cdc-mongo":
+		p.Options.RelayType = "cdc-mongo"
+		rr, err = cdcMongo.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "relay redis-pubsub":
+		p.Options.RelayType = "redis-pubsub"
+		rr, err = rpubsub.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "relay redis-streams":
+		p.Options.RelayType = "redis-streams"
+		rr, err = rstreams.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "relay nsq":
+		p.Options.RelayType = "nsq"
+		rr, err = nsq.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "relay": // Relay (via env vars)
+		rr, err = p.processRelayFlags()
+	default:
+		return fmt.Errorf("unrecognized command: %s", p.Cmd)
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "could not instantiate relayer")
+	}
+
+	if err := p.startGRPCService(); err != nil {
+		return err
+	}
+
+	if err := rr.Relay(); err != nil {
+		return err
+	}
+
+	<-p.MainShutdownContext.Done()
+
+	p.log.Info("Application exiting")
+
+	return nil
+}
+
+// processRelayFlags handles relay from container mode/environment variables
+func (p *Plumber) processRelayFlags() (relay.IRelayBackend, error) {
+	var err error
+	var rr relay.IRelayBackend
+
+	switch p.Options.RelayType {
+	case "kafka":
+		rr, err = kafka.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "gcp-pubsub":
+		rr, err = gcpPubSub.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "mqtt":
+		rr, err = mqtt.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "aws-sqs":
+		rr, err = awssqs.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "rabbit":
+		rr, err = rabbitmq.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "azure":
+		rr, err = azure.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "cdc-mongo":
+		rr, err = cdcMongo.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "redis-pubsub":
+		rr, err = rpubsub.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "redis-streams":
+		rr, err = rstreams.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "cdc-postgres":
+		rr, err = cdcPostgres.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	case "nsq":
+		rr, err = nsq.Relay(p.Options, p.RelayCh, p.ServiceShutdownContext)
+	default:
+		err = fmt.Errorf("unsupported messaging system '%s'", p.Options.RelayType)
+	}
+
+	return rr, err
+}
+
+// parseCmdDynamic handles dynamic replay destination mode commands
+func (p *Plumber) parseCmdDynamic() error {
+	parsedCmd := strings.Split(p.Cmd, " ")
+	switch parsedCmd[1] {
+	case "kafka":
+		return kafka.Dynamic(p.Options)
+	case "rabbit":
+		return rabbitmq.Dynamic(p.Options)
+	case "mqtt":
+		return mqtt.Dynamic(p.Options)
+	case "redis-pubsub":
+		return rpubsub.Dynamic(p.Options)
+	case "redis-streams":
+		return rstreams.Dynamic(p.Options)
+	case "nats":
+		return nats.Dynamic(p.Options)
+	case "nats-streaming":
+		return natsStreaming.Dynamic(p.Options)
+	case "activemq":
+		return activemq.Dynamic(p.Options)
+	case "gcp-pubsub":
+		return gcpPubSub.Dynamic(p.Options)
+	case "aws-sqs":
+		return awssqs.Dynamic(p.Options)
+	case "aws-sns":
+		return awssns.Dynamic(p.Options)
+	case "azure":
+		return azure.Dynamic(p.Options)
+	case "azure-eventhub":
+		return azureEventhub.Dynamic(p.Options)
+	}
+
+	return fmt.Errorf("unrecognized command: %s", p.Cmd)
+}
+
+// parseBatchCmd handles all commands related to Batch.sh API
+func (p *Plumber) parseBatchCmd() error {
+	b := batch.New(p.Options)
+
+	switch {
+	case p.Cmd == "batch login":
+		return b.Login()
+	case p.Cmd == "batch logout":
+		return b.Logout()
+	case p.Cmd == "batch list collection":
+		return b.ListCollections()
+	case p.Cmd == "batch create collection":
+		return b.CreateCollection()
+	case p.Cmd == "batch list destination":
+		return b.ListDestinations()
+	case strings.HasPrefix(p.Cmd, "batch create destination"):
+		commands := strings.Split(p.Cmd, " ")
+		return b.CreateDestination(commands[3])
+	case p.Cmd == "batch list schema":
+		return b.ListSchemas()
+	case p.Cmd == "batch list replay":
+		return b.ListReplays()
+	case p.Cmd == "batch create replay":
+		return b.CreateReplay()
+	case p.Cmd == "batch archive replay":
+		return b.ArchiveReplay()
+	case p.Cmd == "batch search":
+		return b.SearchCollection()
+	default:
+		return fmt.Errorf("unrecognized command: %s", p.Cmd)
+	}
+}

--- a/plumber/plumber.go
+++ b/plumber/plumber.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	ErrMissingShutdownContext  = errors.New("ServiceShutdownContext cannot be nil")
+	ErrMissingShutdownCtx      = errors.New("ServiceShutdownCtx cannot be nil")
 	ErrMissingMainShutdownFunc = errors.New("MainShutdownFunc cannot be nil")
 	ErrMissingMainContext      = errors.New("MainContext cannot be nil")
 	ErrMissingOptions          = errors.New("Options cannot be nil")
@@ -22,11 +22,11 @@ var (
 
 // Config contains configurable options for instantiating a new Plumber
 type Config struct {
-	ServiceShutdownContext context.Context
-	MainShutdownFunc       context.CancelFunc
-	MainShutdownContext    context.Context
-	Options                *cli.Options
-	Cmd                    string
+	ServiceShutdownCtx context.Context
+	MainShutdownFunc   context.CancelFunc
+	MainShutdownCtx    context.Context
+	Options            *cli.Options
+	Cmd                string
 }
 
 type Plumber struct {
@@ -50,15 +50,15 @@ func New(cfg *Config) (*Plumber, error) {
 
 // validateConfig ensures all correct values for Config are passed
 func validateConfig(cfg *Config) error {
-	if cfg.ServiceShutdownContext == nil {
-		return ErrMissingShutdownContext
+	if cfg.ServiceShutdownCtx == nil {
+		return ErrMissingShutdownCtx
 	}
 
 	if cfg.Options == nil {
 		return ErrMissingOptions
 	}
 
-	if cfg.MainShutdownContext == nil {
+	if cfg.MainShutdownCtx == nil {
 		return ErrMissingMainContext
 	}
 
@@ -96,16 +96,16 @@ func (p *Plumber) Run() {
 
 func (p *Plumber) startGRPCService() error {
 	relayCfg := &relay.Config{
-		Token:                  p.Options.RelayToken,
-		GRPCAddress:            p.Options.RelayGRPCAddress,
-		NumWorkers:             p.Options.RelayNumWorkers,
-		Timeout:                p.Options.RelayGRPCTimeout,
-		RelayCh:                p.RelayCh,
-		DisableTLS:             p.Options.RelayGRPCDisableTLS,
-		BatchSize:              p.Options.RelayBatchSize,
-		Type:                   p.Options.RelayType,
-		MainShutdownFunc:       p.MainShutdownFunc,
-		ServiceShutdownContext: p.ServiceShutdownContext,
+		Token:              p.Options.RelayToken,
+		GRPCAddress:        p.Options.RelayGRPCAddress,
+		NumWorkers:         p.Options.RelayNumWorkers,
+		Timeout:            p.Options.RelayGRPCTimeout,
+		RelayCh:            p.RelayCh,
+		DisableTLS:         p.Options.RelayGRPCDisableTLS,
+		BatchSize:          p.Options.RelayBatchSize,
+		Type:               p.Options.RelayType,
+		MainShutdownFunc:   p.MainShutdownFunc,
+		ServiceShutdownCtx: p.ServiceShutdownCtx,
 	}
 
 	grpcRelayer, err := relay.New(relayCfg)
@@ -121,7 +121,7 @@ func (p *Plumber) startGRPCService() error {
 	}()
 
 	// Launch gRPC Relayer
-	if err := grpcRelayer.StartWorkers(p.ServiceShutdownContext); err != nil {
+	if err := grpcRelayer.StartWorkers(p.ServiceShutdownCtx); err != nil {
 		return errors.Wrap(err, "unable to start gRPC relay workers")
 	}
 

--- a/plumber/plumber.go
+++ b/plumber/plumber.go
@@ -1,0 +1,131 @@
+package plumber
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"github.com/batchcorp/plumber/api"
+	"github.com/batchcorp/plumber/cli"
+	"github.com/batchcorp/plumber/printer"
+	"github.com/batchcorp/plumber/relay"
+)
+
+var (
+	ErrMissingShutdownContext  = errors.New("ServiceShutdownContext cannot be nil")
+	ErrMissingMainShutdownFunc = errors.New("MainShutdownFunc cannot be nil")
+	ErrMissingMainContext      = errors.New("MainContext cannot be nil")
+	ErrMissingOptions          = errors.New("Options cannot be nil")
+)
+
+// Config contains configurable options for instantiating a new Plumber
+type Config struct {
+	ServiceShutdownContext context.Context
+	MainShutdownFunc       context.CancelFunc
+	MainShutdownContext    context.Context
+	Options                *cli.Options
+	Cmd                    string
+}
+
+type Plumber struct {
+	*Config
+	RelayCh chan interface{}
+	log     *logrus.Entry
+}
+
+// New instantiates a properly configured instance Plumber, or configuration error
+func New(cfg *Config) (*Plumber, error) {
+	if err := validateConfig(cfg); err != nil {
+		return nil, errors.Wrap(err, "unable to validate config")
+	}
+
+	return &Plumber{
+		Config:  cfg,
+		RelayCh: make(chan interface{}, 1),
+		log:     logrus.WithField("pkg", "plumber"),
+	}, nil
+}
+
+// validateConfig ensures all correct values for Config are passed
+func validateConfig(cfg *Config) error {
+	if cfg.ServiceShutdownContext == nil {
+		return ErrMissingShutdownContext
+	}
+
+	if cfg.Options == nil {
+		return ErrMissingOptions
+	}
+
+	if cfg.MainShutdownContext == nil {
+		return ErrMissingMainContext
+	}
+
+	if cfg.MainShutdownFunc == nil {
+		return ErrMissingMainShutdownFunc
+	}
+
+	return nil
+}
+
+// Run is the main entrypoint to the plumber application
+func (p *Plumber) Run() {
+	var err error
+
+	switch {
+	case strings.HasPrefix(p.Cmd, "batch"):
+		err = p.parseBatchCmd()
+	case strings.HasPrefix(p.Cmd, "read"):
+		err = p.parseCmdRead()
+	case strings.HasPrefix(p.Cmd, "write"):
+		err = p.parseCmdWrite()
+	case strings.HasPrefix(p.Cmd, "relay"):
+		printer.PrintRelayOptions(p.Cmd, p.Options)
+		err = p.parseCmdRelay()
+	case strings.HasPrefix(p.Cmd, "dynamic"):
+		err = p.parseCmdDynamic()
+	default:
+		logrus.Fatalf("unrecognized command: %s", p.Cmd)
+	}
+
+	if err != nil {
+		logrus.Fatalf("Unable to complete command: %s", err)
+	}
+}
+
+func (p *Plumber) startGRPCService() error {
+	relayCfg := &relay.Config{
+		Token:                  p.Options.RelayToken,
+		GRPCAddress:            p.Options.RelayGRPCAddress,
+		NumWorkers:             p.Options.RelayNumWorkers,
+		Timeout:                p.Options.RelayGRPCTimeout,
+		RelayCh:                p.RelayCh,
+		DisableTLS:             p.Options.RelayGRPCDisableTLS,
+		BatchSize:              p.Options.RelayBatchSize,
+		Type:                   p.Options.RelayType,
+		MainShutdownFunc:       p.MainShutdownFunc,
+		ServiceShutdownContext: p.ServiceShutdownContext,
+	}
+
+	grpcRelayer, err := relay.New(relayCfg)
+	if err != nil {
+		return errors.Wrap(err, "unable to create new gRPC relayer")
+	}
+
+	// Launch HTTP server
+	go func() {
+		if err := api.Start(p.Options.RelayHTTPListenAddress, p.Options.Version); err != nil {
+			logrus.Fatalf("unable to start API server: %s", err)
+		}
+	}()
+
+	// Launch gRPC Relayer
+	if err := grpcRelayer.StartWorkers(p.ServiceShutdownContext); err != nil {
+		return errors.Wrap(err, "unable to start gRPC relay workers")
+	}
+
+	go grpcRelayer.WaitForShutdown()
+
+	return nil
+}

--- a/test-assets/cdc-posgres/README.md
+++ b/test-assets/cdc-posgres/README.md
@@ -1,0 +1,15 @@
+# Testing CDC Postgres
+
+1. `docker compose up -d`
+2. Exec into postgres shell
+   ```bash
+   docker exec -it testpostgres psql -U postgres postgres
+   ```
+3. Create test table `create table employees (id int primary key, name varchar, age int);`
+4. Create publication `CREATE PUBLICATION batchsh_plumber FOR ALL TABLES;`
+5. Create replication slot `SELECT * FROM pg_create_logical_replication_slot('plumber_slot', 'pgoutput');` 
+6. Start plumber in read mode
+   ```bash
+   plumber read cdc-postgres --slot plumber_slot --publisher batchsh_plumber --database postgres --host localhost:5432 --username postgres --password postgres
+   ```
+7. Write something to the table `INSERT INTO employees VALUES (1, 'John Doe', 30);`

--- a/test-assets/cdc-posgres/docker-compose.yml
+++ b/test-assets/cdc-posgres/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.4"
+services:
+  postgres:
+    image: "postgres:11"
+    container_name: "testpostgres"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=plumber_db
+    ports:
+      - "5432:5432"
+    command:
+      - "postgres"
+      - "-c"
+      - "wal_level=logical"
+    volumes:
+      - dbdata:/var/lib/postgresql/data
+volumes:
+  dbdata:

--- a/test-assets/nsq/README.md
+++ b/test-assets/nsq/README.md
@@ -1,0 +1,12 @@
+# Testing nsq
+
+1. `docker compose up -d`
+2. Go to http://localhost:4171/lookup and create topic `testing` and channel `plumber`
+3. Write data
+   ```bash
+   plumber write nsq --nsqd-address localhost:4150 --topic testing --input-data hello
+   ```
+4. Read data
+   ```bash
+   plumber read nsq --nsqd-address localhost:4150 --topic testing --channel plumber
+   ```

--- a/test-assets/nsq/docker-compose.yml
+++ b/test-assets/nsq/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.4"
+services:
+  nsqlookupd:
+    image: nsqio/nsq
+    ports:
+      - "4160:4160"
+      - "4161:4161"
+    command: /nsqlookupd
+
+  nsqd:
+    image: nsqio/nsq
+    ports:
+      - "4150:4150"
+      - "4151:4151"
+    links:
+      - nsqlookupd:nsqlookupd
+    command: /nsqd -lookupd-tcp-address=nsqlookupd:4160 -broadcast-address=nsqd
+
+  nsqadmin:
+    image: nsqio/nsq
+    ports:
+      - "4171:4171"
+    links:
+      - nsqlookupd:nsqlookupd
+      - nsqd:nsqd
+    command: /nsqadmin -lookupd-http-address=nsqlookupd:4161

--- a/test-assets/redis-streams/README.md
+++ b/test-assets/redis-streams/README.md
@@ -1,0 +1,9 @@
+# Testing redis-streams
+
+1. docker compose up -d redis
+2. telnet localhost 6379
+3. Create stream
+   ```
+   XADD teststream * sensor-id 1234 temperature 19.8
+   ```
+4. `plumber read redis-streams --streams teststream`


### PR DESCRIPTION
* Watching for shutdown signal and shutting down readers and grpc workers gracefully to ensure all data has been sent to Batch
* Reducing code duplication by moving API/GRPC code outside of every backend's Relay() method
* Moving flag handling to plumber package to cleanup main.go