### PR TITLE
Update stream go client to the last version

### DIFF
--- a/backends/rabbitmq-streams/read.go
+++ b/backends/rabbitmq-streams/read.go
@@ -54,7 +54,9 @@ func (r *RabbitMQStreams) Read() error {
 		}
 
 		if !r.Options.ReadFollow {
-			consumerContext.Consumer.Close()
+			go func() {
+				_ = consumerContext.Consumer.Close()
+			}()
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/onsi/gomega v1.11.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
-	github.com/rabbitmq/rabbitmq-stream-go-client v0.0.0-20210718174647-8ed32be73644
+	github.com/rabbitmq/rabbitmq-stream-go-client v0.0.0-20210727200008-f89eb06a4196
 	github.com/relistan/go-director v0.0.0-20200406104025-dbbf5d95248d
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/segmentio/kafka-go v0.4.16

--- a/go.sum
+++ b/go.sum
@@ -572,6 +572,10 @@ github.com/rabbitmq/rabbitmq-stream-go-client v0.0.0-20210716073243-89ba0a849ed8
 github.com/rabbitmq/rabbitmq-stream-go-client v0.0.0-20210716073243-89ba0a849ed8/go.mod h1:dZtRwYizmzN1EwkcW7/CoN9rFbGSEA7i/889iakOJZE=
 github.com/rabbitmq/rabbitmq-stream-go-client v0.0.0-20210718174647-8ed32be73644 h1:6iCiwan9DONSXD1pKm0sF1zBVu0qtjkU9ba381rmb0I=
 github.com/rabbitmq/rabbitmq-stream-go-client v0.0.0-20210718174647-8ed32be73644/go.mod h1:dZtRwYizmzN1EwkcW7/CoN9rFbGSEA7i/889iakOJZE=
+github.com/rabbitmq/rabbitmq-stream-go-client v0.0.0-20210727200008-f89eb06a4196 h1:/gtwa9NZmHUP0JuWbzbNClPaQjpQHbzGL8gvrz4U00g=
+github.com/rabbitmq/rabbitmq-stream-go-client v0.0.0-20210727200008-f89eb06a4196/go.mod h1:dZtRwYizmzN1EwkcW7/CoN9rFbGSEA7i/889iakOJZE=
+github.com/rabbitmq/rabbitmq-stream-go-client v0.0.0-20210803144326-bc2a362413d5 h1:cYvQBi/kCr/WSUdqatEdstWpPGwQYKT5WOGFwWdtkew=
+github.com/rabbitmq/rabbitmq-stream-go-client v0.0.0-20210803144326-bc2a362413d5/go.mod h1:dZtRwYizmzN1EwkcW7/CoN9rFbGSEA7i/889iakOJZE=
 github.com/rakyll/statik v0.1.7/go.mod h1:AlZONWzMtEnMs7W4e/1LURLiI49pIMmp6V9Unghqrcc=
 github.com/relistan/go-director v0.0.0-20200406104025-dbbf5d95248d h1:NWE6gufaNLgqs6VUzsqXkogQkMEcZxQjdRTSbf79NCA=
 github.com/relistan/go-director v0.0.0-20200406104025-dbbf5d95248d/go.mod h1:zxI04y3OTmbrx/ef0ahmkEy9/eBLLseHAjy6M5iKsws=

--- a/vendor/github.com/rabbitmq/rabbitmq-stream-go-client/LICENSE
+++ b/vendor/github.com/rabbitmq/rabbitmq-stream-go-client/LICENSE
@@ -1,201 +1,25 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (C) 2021 Gabriele Santomaggio
+Portions Copyright (C) vmware
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream/brokers.go
+++ b/vendor/github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream/brokers.go
@@ -8,6 +8,11 @@ import (
 	"sync"
 )
 
+type AddressResolver struct {
+	Host string
+	Port int
+}
+
 type Broker struct {
 	Host      string
 	Port      string
@@ -17,6 +22,8 @@ type Broker struct {
 	Password  string
 	Scheme    string
 	tlsConfig *tls.Config
+	advHost   string
+	advPort   string
 }
 
 func newBrokerDefault() *Broker {
@@ -65,13 +72,16 @@ func (br *Broker) mergeWithDefault() {
 
 }
 
-func (br *Broker) cloneFrom(broker *Broker) {
+func (br *Broker) cloneFrom(broker *Broker, resolver *AddressResolver) {
 	br.User = broker.User
 	br.Password = broker.Password
 	br.Vhost = broker.Vhost
 	br.Scheme = broker.Scheme
 	br.tlsConfig = broker.tlsConfig
-
+	if resolver != nil {
+		br.Host = resolver.Host
+		br.Port = strconv.Itoa(resolver.Port)
+	}
 }
 
 func (br *Broker) GetUri() string {

--- a/vendor/github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream/constants.go
+++ b/vendor/github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream/constants.go
@@ -85,7 +85,7 @@ const (
 	maxBatchSize     = 10_000
 	defaultBatchSize = 100
 	//
-	ClientVersion = "0.10-alpha"
+	ClientVersion = "0.11-alpha"
 
 	StreamTcpPort = "5552"
 )

--- a/vendor/github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream/consumer.go
+++ b/vendor/github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream/consumer.go
@@ -63,6 +63,8 @@ func (consumer *Consumer) GetOffset() int64 {
 }
 
 func (consumer *Consumer) NotifyClose() ChannelClose {
+	consumer.mutex.Lock()
+	defer consumer.mutex.Unlock()
 	ch := make(chan Event, 1)
 	consumer.closeHandler = ch
 	return ch

--- a/vendor/github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream/coordinator.go
+++ b/vendor/github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream/coordinator.go
@@ -76,7 +76,9 @@ func (coordinator *Coordinator) RemoveConsumerById(id interface{}, reason Event)
 
 	if consumer.closeHandler != nil {
 		consumer.closeHandler <- reason
+		close(consumer.closeHandler)
 	}
+
 	return coordinator.removeById(id, coordinator.consumers)
 }
 func (coordinator *Coordinator) RemoveProducerById(id uint8, reason Event) error {
@@ -175,10 +177,6 @@ func (coordinator *Coordinator) RemoveResponseByName(id string) error {
 	coordinator.responses[id] = nil
 	delete(coordinator.responses, id)
 	return nil
-}
-
-func (coordinator *Coordinator) ResponsesCount() int {
-	return coordinator.count(coordinator.responses)
 }
 
 /// Consumer functions

--- a/vendor/github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream/producer.go
+++ b/vendor/github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream/producer.go
@@ -279,7 +279,7 @@ func (producer *Producer) internalBatchSend(messagesSequence []messageSequence) 
 	err := producer.options.client.socket.writeAndFlush(b.Bytes())
 	if err != nil {
 		// This sleep is need to wait the
-		// 200 milliseconds to flush all the pending messages
+		// 800 milliseconds to flush all the pending messages
 		time.Sleep(800 * time.Millisecond)
 		producer.setStatus(closed)
 		producer.FlushUnConfirmedMessages()

--- a/vendor/github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream/socket.go
+++ b/vendor/github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream/socket.go
@@ -22,6 +22,8 @@ func (sck *socket) setOpen() {
 }
 
 func (sck *socket) isOpen() bool {
+	sck.mutex.Lock()
+	defer sck.mutex.Unlock()
 	return atomic.LoadInt32(&sck.closed) == 1
 }
 func (sck *socket) shutdown(err error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -388,7 +388,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/rabbitmq/rabbitmq-stream-go-client v0.0.0-20210718174647-8ed32be73644
+# github.com/rabbitmq/rabbitmq-stream-go-client v0.0.0-20210727200008-f89eb06a4196
 ## explicit
 github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp
 github.com/rabbitmq/rabbitmq-stream-go-client/pkg/logs


### PR DESCRIPTION
Add go-routine to close the consumer.

The [consumer code](https://github.com/batchcorp/plumber/compare/master...Gsantomaggio:update_go_stream_client?expand=1#diff-728454cce08d9da7b3706f88a52232bda6e02d17eef8023232b1b2d1bc612249R57-R59)  runs in the main I/O threads. So closing directly the consumer could hang the code. 
Added a go-routine to save close the consumer.

I will add a specific call on the `consumerContext` to close the consumer inside the handler thread.