### PR TITLE
Fix Redis-pubsub connection issues

### DIFF
--- a/backends/rpubsub/relay.go
+++ b/backends/rpubsub/relay.go
@@ -2,11 +2,8 @@ package rpubsub
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"time"
 
-	"github.com/batchcorp/plumber/util"
 	"github.com/go-redis/redis/v8"
 	"github.com/pkg/errors"
 	"github.com/relistan/go-director"
@@ -50,47 +47,27 @@ func (r *Redis) Relay(ctx context.Context, relayCh chan interface{}, errorCh cha
 	sub := r.client.Subscribe(ctx, r.Options.RedisPubSub.Channels...)
 	defer sub.Unsubscribe(ctx, r.Options.RedisPubSub.Channels...)
 
+	msgCh := sub.Channel()
+
 	for {
 		// Redis library is not handling context cancellation, only timeouts. So we must use a timeout here
 		// to ensure we eventually receive the context cancellation from ShutdownCtx
-		timeoutCtx, _ := context.WithTimeout(ctx, time.Second*5)
+		select {
+		case <-ctx.Done():
+			r.log.Info("Received shutdown signal, exiting relayer")
+			return nil
+		case msg := <-msgCh:
+			stats.Incr("redis-pubsub-relay-consumer", 1)
 
-		msg, err := sub.ReceiveMessage(timeoutCtx)
-		if err != nil {
-			// When a timeout occurs
-			if strings.Contains(err.Error(), "operation was canceled") {
-				r.log.Info("Received shutdown signal, exiting relayer")
-				break
+			r.log.Debugf("Relaying message received on channel '%s' to Batch (contents: %s)",
+				msg.Channel, msg.Payload)
+
+			relayCh <- &rtypes.RelayMessage{
+				Value:   msg,
+				Options: &rtypes.RelayMessageOptions{},
 			}
-
-			// This will happen every loop when the context times out
-			if strings.Contains(err.Error(), "i/o timeout") {
-				time.Sleep(time.Millisecond * 100)
-				continue
-			}
-
-			// Temporarily mute stats
-			stats.Mute("redis-pubsub-relay-consumer")
-			stats.Mute("redis-pubsub-relay-producer")
-
-			stats.IncrPromCounter("plumber_read_errors", 1)
-
-			expandedErr := fmt.Errorf("unable to read message: %s (retrying in %s)", err, RetryReadInterval)
-			util.WriteError(r.log, errorCh, expandedErr)
-
-			time.Sleep(RetryReadInterval)
-
-			continue
-		}
-
-		stats.Incr("redis-pubsub-relay-consumer", 1)
-
-		r.log.Debugf("Relaying message received on channel '%s' to Batch (contents: %s)",
-			msg.Channel, msg.Payload)
-
-		relayCh <- &rtypes.RelayMessage{
-			Value:   msg,
-			Options: &rtypes.RelayMessageOptions{},
+		default:
+			// NOOP
 		}
 	}
 


### PR DESCRIPTION
Fix for connection issues and logspam

```
redis: 2021/08/17 16:48:20 pubsub.go:159: redis: discarding bad PubSub connection: read tcp [::1]:59390->[::1]:6379: i/o timeout
redis: 2021/08/17 16:48:25 pubsub.go:159: redis: discarding bad PubSub connection: read tcp [::1]:59392->[::1]:6379: i/o timeout
```

Proper way to read concurrently is to use the subscription channel. This also helped clean up the code a bit