### PR TITLE
Tunnel update fixes

### DIFF
--- a/actions/tunnel.go
+++ b/actions/tunnel.go
@@ -172,7 +172,7 @@ func (a *Actions) UpdateTunnel(ctx context.Context, tunnelID string, tunnelOpts 
 	}
 	d.Backend = be
 
-	if tunnelOpts.XActive == true {
+	if tunnelOpts.XActive {
 		if err := d.StartTunnel(5 * time.Second); err != nil {
 			return nil, errors.Wrap(err, "unable to start tunnel")
 		}


### PR DESCRIPTION
* Allow tunnels to be stopped/started based on `Active` flag on update
* Stop tunnels when updating, and relaunch after update with new config