### PR TITLE
backends/batch: fix dropped error

### DIFF
--- a/backends/batch/collections.go
+++ b/backends/batch/collections.go
@@ -120,18 +120,18 @@ func (b *Batch) search(from, size, page int) error {
 
 	res, _, err := b.Post("/v1/collection/"+b.Opts.Batch.Search.CollectionId+"/search", p)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "unable to complete search request")
 	}
 
 	results := &SearchResult{}
 	if err := json.Unmarshal(res, results); err != nil {
-		b.Log.Fatalf("Failed to search collection: %s", err)
+		return errors.Wrap(err, "failed to search collection")
 	}
 
 	// Our JSON output should be human readable
 	m, err := json.MarshalIndent(results.Data, "", "  ")
 	if err != nil {
-		b.Log.Fatalf("Could not display search results: %s", err)
+		return errors.Wrap(err, "could not display search results")
 	}
 
 	// Display JSON results

--- a/backends/batch/collections.go
+++ b/backends/batch/collections.go
@@ -119,6 +119,9 @@ func (b *Batch) search(from, size, page int) error {
 	}
 
 	res, _, err := b.Post("/v1/collection/"+b.Opts.Batch.Search.CollectionId+"/search", p)
+	if err != nil {
+		return err
+	}
 
 	results := &SearchResult{}
 	if err := json.Unmarshal(res, results); err != nil {


### PR DESCRIPTION
This fixes a dropped `err` in `backends/batch`.

Some of the nearby code in `search()` chooses to log instead of return on an error condition, even though the function's only return is an error. My fix returns the error, would it be better to just log instead? 