### PR TITLE
backends/kafka: fix dropped error

### DIFF
--- a/backends/kafka/lag.go
+++ b/backends/kafka/lag.go
@@ -259,7 +259,9 @@ func (l *Lag) getPartitionLag(ctx context.Context, topic string, groupId string,
 
 	// get last offset per partition
 	lastOffset, err := l.GetPartitionLastOffset(topic, part)
-
+	if err != nil {
+		return -1, errors.Wrap(err, "Unable to get last partion offset")
+	}
 	// obtain last committed offset for a given partition and consumer group
 	kafkaClient := &skafka.Client{Addr: remoteAddr}
 


### PR DESCRIPTION
This fixes a dropped `err` variable in `backends/kafka`.