### PR TITLE
main: fix dropped error

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,6 +102,9 @@ func main() {
 	a, err := actions.New(&actions.Config{
 		PersistentConfig: persistentConfig,
 	})
+	if err != nil {
+		logrus.Fatal(err)
+	}
 
 	p, err := plumber.New(&plumber.Config{
 		PersistentConfig:   persistentConfig,


### PR DESCRIPTION
This picks up a dropped `err` variable in `main()`.