### PR TITLE
Increase the test coverage on the validate package

### DIFF
--- a/validate/server.go
+++ b/validate/server.go
@@ -30,22 +30,25 @@ var (
 
 	// Relay
 
-	ErrRelayNotFound      = errors.New("relay not found")
-	ErrRelayNotActive     = errors.New("relay not active")
-	ErrRelayAlreadyActive = errors.New("relay already active")
+	ErrMissingRelayOptions    = errors.New("relay options cannot be nil")
+	ErrMissingCollectionToken = errors.New("collection token cannot be empty")
+	ErrMissingConnectionId    = errors.New("connection id cannot be empty")
+	ErrRelayNotFound          = errors.New("relay not found")
+	ErrRelayNotActive         = errors.New("relay not active")
+	ErrRelayAlreadyActive     = errors.New("relay already active")
 )
 
 func RelayOptionsForServer(relayOptions *opts.RelayOptions) error {
 	if relayOptions == nil {
-		return errors.New("relay options cannot be nil")
+		return ErrMissingRelayOptions
 	}
 
 	if relayOptions.CollectionToken == "" {
-		return errors.New("collection token cannot be empty")
+		return ErrMissingCollectionToken
 	}
 
 	if relayOptions.ConnectionId == "" {
-		return errors.New("connection id cannot be empty")
+		return ErrMissingConnectionId
 	}
 
 	if relayOptions.XBatchshGrpcAddress == "" {

--- a/validate/server_suite_test.go
+++ b/validate/server_suite_test.go
@@ -1,0 +1,13 @@
+package validate_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Validate Suite")
+}

--- a/validate/server_test.go
+++ b/validate/server_test.go
@@ -1,245 +1,71 @@
 package validate
 
-//import (
-//	"github.com/batchcorp/plumber-schemas/build/go/protos/opts"
-//	. "github.com/onsi/ginkgo"
-//	. "github.com/onsi/gomega"
-//	uuid "github.com/satori/go.uuid"
-//
-//	"github.com/batchcorp/plumber-schemas/build/go/protos"
-//	"github.com/batchcorp/plumber-schemas/build/go/protos/args"
-//	"github.com/batchcorp/plumber-schemas/build/go/protos/encoding"
-//)
-//
-//var _ = Describe("Validation", func() {
-//	Context("ConnectionOptions", func() {
-//		It("validates missing conn", func() {
-//			err := ConnectionOptions(nil)
-//			Expect(err).To(HaveOccurred())
-//			Expect(err).To(Equal(ErrMissingConnectionOptions))
-//		})
-//
-//		It("validates missing name", func() {
-//			err := ConnectionOptions(&opts.ConnectionOptions{
-//				Conn: &protos.Connection_Kafka{
-//					Kafka: &conns.Kafka{},
-//				},
-//			})
-//			Expect(err).To(HaveOccurred())
-//			Expect(err).To(Equal(ErrMissingConnName))
-//		})
-//
-//		It("validates missing bus config", func() {
-//			err := ConnectionOptions(&protos.Connection{
-//				Name: "testing",
-//			})
-//			Expect(err).To(HaveOccurred())
-//			Expect(err).To(Equal(ErrMissingConnectionType))
-//		})
-//	})
-//
-//	Context("validateConnectionKafka", func() {
-//		It("validates missing broker address", func() {
-//			k := &conns.Kafka{
-//				Address:  nil,
-//				SaslType: conns.SASLType_NONE,
-//			}
-//
-//			err := validateConnectionKafka(k)
-//			Expect(err).To(HaveOccurred())
-//			Expect(err).To(Equal(ErrMissingAddress))
-//		})
-//
-//		It("validates missing username", func() {
-//			k := &conns.Kafka{
-//				Address:      []string{"1.2.3.4:9200"},
-//				SaslType:     conns.SASLType_PLAIN,
-//				SaslPassword: "foo",
-//			}
-//
-//			err := validateConnectionKafka(k)
-//			Expect(err).To(HaveOccurred())
-//			Expect(err).To(Equal(ErrMissingUsername))
-//		})
-//
-//		It("validates missing password", func() {
-//			k := &conns.Kafka{
-//				Address:      []string{"1.2.3.4:9200"},
-//				SaslType:     conns.SASLType_PLAIN,
-//				SaslUsername: "foo",
-//			}
-//
-//			err := validateConnectionKafka(k)
-//			Expect(err).To(HaveOccurred())
-//			Expect(err).To(Equal(ErrMissingPassword))
-//		})
-//	})
-//
-//	Context("validateRead", func() {
-//		It("validates missing read", func() {
-//			err := validateRead(nil)
-//			Expect(err).To(HaveOccurred())
-//			Expect(err).To(Equal(ErrMissingRead))
-//		})
-//
-//		It("validates missing read", func() {
-//			read := &protos.Read{
-//				Name:          "testing",
-//				ConnectionId:  "",
-//				ReadOptions:   &protos.ReadOptions{},
-//				SampleOptions: &protos.SampleOptions{},
-//				DecodeOptions: &encoding.Options{},
-//			}
-//
-//			err := validateRead(read)
-//			Expect(err).To(HaveOccurred())
-//			Expect(err).To(Equal(ErrMissingConnectionID))
-//		})
-//
-//		It("validates missing read", func() {
-//			read := &protos.Read{
-//				Name:          "testing",
-//				ConnectionId:  uuid.NewV4().String(),
-//				ReadOptions:   &protos.ReadOptions{},
-//				SampleOptions: &protos.SampleOptions{},
-//			}
-//
-//			err := validateRead(read)
-//			Expect(err).To(HaveOccurred())
-//			Expect(err).To(Equal(ErrMissingReadType))
-//		})
-//	})
-//
-//	Context("validateArgsKafka", func() {
-//		It("validate missing kafka args", func() {
-//			err := validateArgsKafka(nil)
-//			Expect(err).To(HaveOccurred())
-//			Expect(err).To(Equal(ErrMissingKafkaArgs))
-//		})
-//
-//		It("validates missing topics", func() {
-//			cfg := &args.Kafka{
-//				Topics: nil,
-//			}
-//
-//			err := validateArgsKafka(cfg)
-//			Expect(err).To(HaveOccurred())
-//			Expect(err).To(Equal(ErrMissingTopic))
-//		})
-//
-//		It("validates missing consumer group name", func() {
-//			cfg := &args.Kafka{
-//				Topics:           []string{"testing"},
-//				UseConsumerGroup: true,
-//			}
-//
-//			err := validateArgsKafka(cfg)
-//			Expect(err).To(HaveOccurred())
-//			Expect(err).To(Equal(ErrMissingConsumerGroupName))
-//		})
-//
-//		It("passes validation", func() {
-//			cfg := &args.Kafka{
-//				Topics: []string{"testing"},
-//			}
-//
-//			err := validateArgsKafka(cfg)
-//			Expect(err).ToNot(HaveOccurred())
-//		})
-//	})
-//
-//	Context("validateDecodeOptions", func() {
-//		It("returns nil when passed nil", func() {
-//			err := validateDecodeOptions(nil)
-//			Expect(err).ToNot(HaveOccurred())
-//		})
-//	})
-//
-//	Context("validateDecodeOptionsProtobuf", func() {
-//		It("returns nil when passed nil", func() {
-//			err := validateDecodeOptionsProtobuf(nil)
-//			Expect(err).ToNot(HaveOccurred())
-//		})
-//
-//		It("validates missing root type", func() {
-//			opts := &encoding.Protobuf{
-//				ZipArchive: []byte(`1`),
-//			}
-//
-//			err := validateDecodeOptionsProtobuf(opts)
-//			Expect(err).To(HaveOccurred())
-//			Expect(err).To(Equal(ErrMissingRootType))
-//		})
-//
-//		It("validates missing zip archive", func() {
-//			opts := &encoding.Protobuf{
-//				RootType: "events.Message",
-//			}
-//
-//			err := validateDecodeOptionsProtobuf(opts)
-//			Expect(err).To(HaveOccurred())
-//			Expect(err).To(Equal(ErrMissingZipArchive))
-//		})
-//	})
-//
-//	Context("validateDecodeOptionsAvro", func() {
-//		It("returns nil when passed nil", func() {
-//			err := validateDecodeOptionsAvro(nil)
-//			Expect(err).ToNot(HaveOccurred())
-//		})
-//
-//		It("validates missing schema", func() {
-//			err := validateDecodeOptionsAvro(&encoding.Avro{})
-//			Expect(err).To(HaveOccurred())
-//			Expect(err).To(Equal(ErrMissingAVROSchema))
-//		})
-//
-//		It("passes validation", func() {
-//			err := validateDecodeOptionsAvro(&encoding.Avro{Schema: []byte(`1`)})
-//			Expect(err).ToNot(HaveOccurred())
-//		})
-//	})
-//
-//	Context("validateService", func() {
-//		It("errors when passed nil", func() {
-//			err := validateService(nil)
-//			Expect(err).To(HaveOccurred())
-//			Expect(err).To(Equal(ErrMissingService))
-//		})
-//
-//		It("validates missing name", func() {
-//			svc := &protos.Service{
-//				Name:    "",
-//				OwnerId: uuid.NewV4().String(),
-//			}
-//
-//			err := validateService(svc)
-//			Expect(err).To(HaveOccurred())
-//			Expect(err).To(Equal(ErrMissingName))
-//		})
-//
-//		// TODO: uncomment when I figure out what owner should be
-//		//It("validates missing owner ID", func() {
-//		//	svc := &protos.Service{
-//		//		Name:    "testing",
-//		//		OwnerId: "",
-//		//	}
-//		//
-//		//	err := validateService(svc)
-//		//	Expect(err).To(HaveOccurred())
-//		//	Expect(err).To(Equal(ErrMissingOwner))
-//		//})
-//
-//		It("validates repo url", func() {
-//			svc := &protos.Service{
-//				Name:    "testing",
-//				OwnerId: uuid.NewV4().String(),
-//				RepoUrl: "foo",
-//			}
-//
-//			err := validateService(svc)
-//			Expect(err).To(HaveOccurred())
-//			Expect(err).To(Equal(ErrInvalidRepoURL))
-//		})
-//	})
-//})
+import (
+	"github.com/batchcorp/plumber-schemas/build/go/protos/opts"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Validation", func() {
+
+	Context("ConnectionOptionsForServer", func() {
+		It("validates missing conn options", func() {
+			err := ConnectionOptionsForServer(nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(Equal(ErrMissingConnectionOptions))
+		})
+
+		It("validates missing name", func() {
+			err := ConnectionOptionsForServer(&opts.ConnectionOptions{})
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(Equal(ErrMissingConnName))
+		})
+
+		It("validates missing bus config", func() {
+			err := ConnectionOptionsForServer(&opts.ConnectionOptions{
+				Name: "testing",
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(Equal(ErrMissingConnectionType))
+		})
+	})
+
+	Context("RelayOptionsForServer", func() {
+		It("validates missing conn options", func() {
+			err := RelayOptionsForServer(nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(Equal(ErrMissingRelayOptions))
+		})
+
+		It("validates missing collection token", func() {
+			err := RelayOptionsForServer(&opts.RelayOptions{
+				CollectionToken: "",
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(Equal(ErrMissingCollectionToken))
+		})
+
+		It("validates missing connection ID", func() {
+			err := RelayOptionsForServer(&opts.RelayOptions{
+				ConnectionId:    "",
+				CollectionToken: "TOKEN",
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(Equal(ErrMissingConnectionId))
+		})
+
+		It("falls back to the default GRPCCollectorAddress and GRPCTimeout if none is given", func() {
+			relayOptions := &opts.RelayOptions{
+				XBatchshGrpcAddress: "",
+				CollectionToken:     "TOKEN",
+				ConnectionId:        "ConnId",
+			}
+			err := RelayOptionsForServer(relayOptions)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(relayOptions.XBatchshGrpcAddress).To(Equal("grpc-collector.batch.sh:9000"))
+			Expect(relayOptions.XBatchshGrpcTimeoutSeconds).To(Equal(5))
+		})
+
+	})
+})


### PR DESCRIPTION
## What was changed?
Uncomment and remove old tests for the validate package and add coverage for `RelayOptionsForServer` and `ConnectionOptionsForServer`

## Why was it changed?
To increase test coverage