### PR TITLE
Add target for doing dev while improving test coverage to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ start-*.sh
 data
 data/*
 c.out
+cover.html

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,14 @@ test/coverage: GOFLAGS=
 test/coverage:
 	$(GO) test ./... -coverprofile c.out
 
+.PHONY: test/dev
+test/dev: description = Run Go unit tests, output coverage information to a browser
+test/dev: GOFLAGS=
+test/dev:
+	$(GO) test ./... -coverprofile c.out
+	$(GO) tool cover -html=c.out -o cover.html
+	open cover.html
+
 .PHONY: test/functional
 test/functional: description = Run functional tests
 test/functional: GOFLAGS=


### PR DESCRIPTION
## What was changed?
Add a target to the Makefile that I had been using locally for identifying gaps in test coverage. 

## Why was it changed?
To make it easier for other folks to improve coverage while doing development.