### PR TITLE
Fixing NATS cleanup on shutdown

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func main() {
 	defer persistentConfig.Save()
 
 	// We only want to intercept interrupt signals in relay or server mode
-	if cliOpts.Global.XAction == "relay" || cliOpts.Global.XAction == "server" {
+	if cliOpts.Global.XAction == "relay" || cliOpts.Global.XAction == "server" || cliOpts.Global.XAction == "read" {
 		logrus.Debug("Intercepting signals")
 
 		c := make(chan os.Signal, 1)
@@ -74,9 +74,8 @@ func main() {
 
 		go func() {
 			sig := <-c
-			logrus.Info("Shutting down plumber server...")
 			logrus.Debugf("Received system call: %+v", sig)
-
+			logrus.Info("Shutting down plumber...")
 			serviceShutdownFunc()
 		}()
 


### PR DESCRIPTION
Read will now properly allow cleanup of NATS resources after a non-continuous read, or after a sigterm is received during a continuous read. Previously `main()` was exiting before deferred cleanup functions could run

Thanks @edarha for the report and fix!