### PR TITLE
doc(examples): sub-id arg renamed to subscription-id

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -210,7 +210,7 @@ plumber read redis-streams --address="localhost:6379" --streams="new-orders"
 ##### GCP Pub/Sub
 
 ```bash
-plumber read gcp-pubsub --project-id=PROJECT_ID --sub-id=SUBSCRIPTION
+plumber read gcp-pubsub --project-id=PROJECT_ID --subscription-id=SUBSCRIPTION
 ```
 
 ##### MQTT


### PR DESCRIPTION
gcp-pubsub `sub-id` arg was renamed to `subscription-id`