### PR TITLE
Ignore context.Canceled error on redis-streams read exit

### DIFF
--- a/backends/rstreams/read.go
+++ b/backends/rstreams/read.go
@@ -44,6 +44,10 @@ func (r *RedisStreams) Read(ctx context.Context, readOpts *opts.ReadOptions, res
 		}).Result()
 
 		if err != nil {
+			// Don't report ctrl+c as an error
+			if errors.Is(err, context.Canceled) {
+				return nil
+			}
 			return fmt.Errorf("unable to read from streamsResult: %s", err)
 		}
 


### PR DESCRIPTION
No need to report this as an error