### PR TITLE
Ignore telemetry service errors

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -39,6 +39,8 @@ type Telemetry struct {
 
 type NoopTelemetry struct{}
 
+type NoopLogger struct{}
+
 func New(cfg *Config) (*Telemetry, error) {
 	if err := validateConfig(cfg); err != nil {
 		return nil, errors.Wrap(err, "unable to validate config")
@@ -49,6 +51,7 @@ func New(cfg *Config) (*Telemetry, error) {
 		Transport: cfg.RoundTripper, // posthog lib will instantiate a default roundtripper if nil
 		BatchSize: 1,
 		Interval:  250 * time.Millisecond,
+		Logger:    &NoopLogger{},
 	})
 
 	if err != nil {
@@ -134,4 +137,12 @@ func (t *Telemetry) Enqueue(c posthog.Capture) error {
 
 func (t *NoopTelemetry) Enqueue(_ posthog.Capture) error {
 	return nil
+}
+
+func (l *NoopLogger) Logf(format string, args ...interface{}) {
+	// NOOP
+}
+
+func (l *NoopLogger) Errorf(format string, args ...interface{}) {
+	// NOOP
 }


### PR DESCRIPTION
Prevent plumber from spewing errors to CLI on telemetry service outage